### PR TITLE
Fixing foreign-encoded-octet-count

### DIFF
--- a/uffi-compat/uffi-compat.lisp
+++ b/uffi-compat/uffi-compat.lisp
@@ -653,6 +653,6 @@ output to *trace-output*.  Returns the shell's exit code."
   `(babel:octets-to-string
     :encoding (or ,encoding cffi:*default-foreign-encoding*)))
 
-(defun foreign-encoded-octet-count (str &key encoding)
+(defmacro foreign-encoded-octet-count (str &key encoding)
   `(babel:string-size-in-octets
     ,str :encoding (or ,encoding cffi:*default-foreign-encoding*)))


### PR DESCRIPTION
uffi-compat: passthrough to babel that returns a list form instead of a value is now macroized.

It appears pretty obvious that it was meant to be a macro as that's the way it is constructed. Usages of it expect the count returned, not a list of lisp code.
