### PR TITLE
Minor fix for AllegroCL's long long support

### DIFF
--- a/src/cffi-allegro.lisp
+++ b/src/cffi-allegro.lisp
@@ -252,7 +252,7 @@ WITH-POINTER-TO-VECTOR-DATA."
 
 (defun convert-to-lisp-type (type)
   (ecase type
-    ((:char :short :int :long)
+    ((:char :short :int :long :nat)
      `(signed-byte ,(* 8 (ff:sizeof-fobject type))))
     ((:unsigned-char :unsigned-short :unsigned-int :unsigned-long :unsigned-nat)
      `(unsigned-byte ,(* 8 (ff:sizeof-fobject type))))


### PR DESCRIPTION
And I've confirmed long long works in 64bit AllegroCL/Linux x8664 (Ubuntu 11.10).

I think the segfault mentioned by Robert Goldman is in test 'defcfun.bff.1 and 'defcfun.bff.2, however 'defcfun.bff.1 doesn't have long-long types so I suppose it's not related.

Cheers,
Jianshi
