### PR TITLE
Make GCC search for non-base include directories on FreeBSD.

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -244,7 +244,9 @@ int main(int argc, char**argv) {
    #+darwin (list "-I" "/opt/local/include/")
    #-darwin nil
    ;; ECL internal flags
-   #+ecl (list c::*cc-flags*)))
+   #+ecl (list c::*cc-flags*)
+   ;; FreeBSD non-base header files
+   #+freebsd (list "-I" "/usr/local/include/")))
 
 ;;; FIXME: is there a better way to detect whether these flags
 ;;; are necessary?


### PR DESCRIPTION
On FreeBSD, GCC only looks in directories of the base
system (/usr/include). We need to manually add /usr/local/include if we want
to be able to bind libraries installed by packages or ports.
