### PR TITLE
Allow static symbol references in ECL

### DIFF
--- a/src/cffi-ecl.lisp
+++ b/src/cffi-ecl.lisp
@@ -290,7 +290,7 @@ WITH-POINTER-TO-VECTOR-DATA."
                 ;; On AMD64, the following code only works with the extra
                 ;; argument ",...". If this is not present, functions
                 ;; like sprintf do not work
-                (format s "extern ~A ~A(~@[~{~A~^, ~}~]); ~A~A(~A);"
+                (format s "{ extern ~A ~A(~@[~{~A~^, ~}~]); ~A~A(~A); }"
                         (ecl-type->c-type return-type) pointer types
                         (if (eq return-type :void) "" "@(return) = ")
                         pointer


### PR DESCRIPTION
CFFI currently translates all function calls to a function-pointer-call + foreign-symbol-pointer. This is  not only highly inefficient for a system that can use the system linker at compilation time but it is also impossible in some platforms (most notable iOS).

The patch attached allows the user to select which type of backend he or she wants to use when compiling code with CFFI:
- A backend based on libffi which calls dlopen() every time a function is called
- A backend based on C/C++ compiled code which also calls dlopen()
- A backend based on C/C++ compiled code which uses the linker to resolve symbol references at link time.

The last one is the most efficient possibility, but can only be used when ECL knows which library it has to include in the linking process. Since CFFI does not have at the moment a possibility to interfere at compilation time with load-foreign-library, this is left to the user (some help on this would be appreciated but would involve loading the backend _after_ CFFI's code itself).
