### PR TITLE
Multiple c-names and optional flag for bitfield grovel definitions

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -6557,8 +6557,8 @@ signalled if the platform supports neither @code{AF_PACKET} nor
 
 @deffn {Grovel Form} bitfield name-and-opts &rest elements
 
-Defines a bitfield, with elements specified as @code{((lisp-name
-c-name) &key documentation)}.  @var{name-and-opts} can be either a
+Defines a bitfield, with elements specified as @code{((lisp-name &rest
+c-names) &key optional documentation)}.  @var{name-and-opts} can be either a
 symbol as name, or a list @code{(name &key base-type)}.  For example:
 @end deffn
 
@@ -6566,10 +6566,11 @@ symbol as name, or a list @code{(name &key base-type)}.  For example:
 (bitfield flags-ctype
   ((:flag-a "FLAG_A")
     :documentation "DOCU_A")
-  ((:flag-b "FLAG_B")
+  ((:flag-b "FLAG_B" "FLAG_B_ALT")
     :documentation "DOCU_B")
   ((:flag-c "FLAG_C")
-    :documentation "DOCU_C"))
+    :documentation "DOCU_C"
+    :optional t))
 @end lisp
 
 


### PR DESCRIPTION
These features are already supported by constantenum definitions, we just make
them available for bitfields.
