### PR TITLE
Adding WITH-ERRNO and GET-ERRNO macros

### DIFF
--- a/src/cffi-sbcl.lisp
+++ b/src/cffi-sbcl.lisp
@@ -299,12 +299,14 @@ WITH-POINTER-TO-VECTOR-DATA."
     (extern-alien ,name (function ,rettype ,@types))
     ,@fargs))
 
-(defmacro %foreign-funcall (name args &key library convention)
+(defmacro %foreign-funcall (name args &key library convention errno)
   "Perform a foreign function call, document it more later."
   (declare (ignore library convention))
   (multiple-value-bind (types fargs rettype)
       (foreign-funcall-type-and-args args)
-    `(%%foreign-funcall ,name ,types ,fargs ,rettype)))
+    (if errno `(values (%%foreign-funcall ,name ,types ,fargs ,rettype)
+                       (sb-alien:get-errno))
+        `(%%foreign-funcall ,name ,types ,fargs ,rettype))))
 
 (defmacro %foreign-funcall-pointer (ptr args &key convention)
   "Funcall a pointer to a foreign function."

--- a/src/functions.lisp
+++ b/src/functions.lisp
@@ -49,7 +49,7 @@
      ,@body))
 
 (defmacro get-errno ()
-  *errno*)
+  `*errno*)
 
 ;;;# Calling Foreign Functions
 ;;;

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -164,4 +164,7 @@
    #:defcvar
    #:get-var-pointer
    #:foreign-symbol-pointer
+
+   #:with-errno
+   #:get-errno
    ))


### PR DESCRIPTION
This introduces two macros, with-errno and get-errno to safely retrieve the errno value of a foreign call in a multithreaded environment. It looks something like this:

(with-errno
  (foreign-funcall ...)
  (get-errno))

This feature is being discussed on the [mailing list](http://www.mail-archive.com/cffi-devel@common-lisp.net/msg02388.html).