### PR TITLE
Support loading libffi on OS X & LispWorks

### DIFF
--- a/libffi/init.lisp
+++ b/libffi/init.lisp
@@ -28,7 +28,7 @@
 (in-package #:cffi)
 
 (define-foreign-library (libffi)
-  (:darwin (:or "libffi.dylib" "libffi32.dylib"))
+  (:darwin (:or "libffi.dylib" "libffi32.dylib" "/usr/lib/libffi.dylib"))
   (:solaris (:or "/usr/lib/amd64/libffi.so" "/usr/lib/libffi.so"))
   (:unix (:or "libffi.so.6" "libffi32.so.6" "libffi.so.5" "libffi32.so.5"))
   (:windows (:or "libffi-6.dll" "libffi-5.dll" "libffi.dll"))


### PR DESCRIPTION
When loading `cffi-libffi` on LispWorks 6.1.1 64-bit on OS X, the library is not found.  By default OS X searches for library by their full path (see `dyld` manual on Dynamic Library Loading), and `libffi` is a standard component of the OS, so the full path should be given.
