### PR TITLE
Update cffi-uffi-compat to prevent deprecation warnings

### DIFF
--- a/uffi-compat/uffi-compat.lisp
+++ b/uffi-compat/uffi-compat.lisp
@@ -227,10 +227,10 @@ field-name"
 ;; TODO: figure out why the compiler macro is kicking in before
 ;; the setf expander.
 (defun %foreign-slot-value (obj type field)
-  (cffi:foreign-slot-value obj type field))
+  (cffi:foreign-slot-value obj `(:struct ,type) field))
 
 (defun (setf %foreign-slot-value) (value obj type field)
-  (setf (cffi:foreign-slot-value obj type field) value))
+  (setf (cffi:foreign-slot-value obj `(:struct ,type) field) value))
 
 (defmacro get-slot-value (obj type field)
   "Access a slot value from a structure."


### PR DESCRIPTION
I run clsql with cffi-uffi-compat and after a recent quicklisp update I started seeing deprecation warnings from get-slot-value.  This patch prevents the style warning and still seems to allow correct structure access.

Thanks for the library and good work!
