### PR TITLE
CFFI-libffi fixed for windows

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -245,7 +245,7 @@ int main(int argc, char**argv) {
 
 (defparameter *cc*
   #+(or cygwin (not windows)) "cc"
-  #+(and windows (not cygwin)) "c:/msys/1.0/bin/gcc.exe")
+  #+(and windows (not cygwin)) "gcc")
 
 (defparameter *cc-flags*
   (append


### PR DESCRIPTION
This should fix things with loading CFFI-libffi in Windows. Please tell me if there's anything that needs to be changed, I'd like to see this merged. Also I give a thanks to stassats.

CCL and SBCL loaded correctly. CMU and SCL should theoretically work as well.
