### PR TITLE
grovel: support files with multiple dots in names

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -223,9 +223,19 @@ int main(int argc, char**argv) {
 
 (defparameter *exe-extension* #-windows nil #+windows "exe")
 
+(defun change-pathname-type (path type)
+  (if type
+      (make-pathname :type type :defaults path)
+      (let* ((name (pathname-name path))
+             (dot (position #\. name :from-end t)))
+        (if dot
+            (make-pathname :name (subseq name 0 dot)
+                           :type (subseq name (1+ dot))
+                           :defaults path)
+            (make-pathname :type nil :defaults path)))))
+
 (defun exe-filename (defaults)
-  (let ((path (make-pathname :type *exe-extension*
-                             :defaults defaults)))
+  (let ((path (change-pathname-type defaults *exe-extension*)))
     ;; It's necessary to prepend "./" to relative paths because some
     ;; implementations of INVOKE use a shell.
     (when (or (not (pathname-directory path))


### PR DESCRIPTION
This fixes Quicklisp issue [#758](https://github.com/quicklisp/quicklisp-projects/issues/758) with [libssh2.asd](https://bitbucket.org/alxchk/cl-libssh2/src/a040f346354c65bfe218d054c668b948817fa325/libssh2.asd?at=default) that contains `libssh2-libc.cffi.lisp`, which causes error mentioned in the Quicklisp issue: [failtail.txt](http://report.quicklisp.org/cl-libssh2/2014-09-26/failtail.txt).

Without this patch `(namestring (cffi-grovel::exe-filename #P"a.b.c"))` produces an error under SBCL.