### PR TITLE
commented out the style warning as it seriously degrades the performa…

### DIFF
--- a/src/types.lisp
+++ b/src/types.lisp
@@ -600,10 +600,13 @@ The foreign array must be freed with foreign-array-free."
   (check-type struct-or-union (member :struct :union))
   (let* ((struct-type-name `(,struct-or-union ,name))
          (struct-type (parse-type struct-type-name)))
-    (simple-style-warning
-     "bare references to struct types are deprecated. ~
-      Please use ~S or ~S instead."
-     `(:pointer ,struct-type-name) struct-type-name)
+    ;;(simple-style-warning
+    ;; "bare references to struct types are deprecated. ~
+    ;;  Please use ~S or ~S instead of ~A ~A."
+    ;; `(:pointer ,struct-type-name)
+    ;; struct-type-name
+    ;; name
+    ;; struct-or-union)
     (make-instance (class-of struct-type)
                    :alignment (alignment struct-type)
                    :size (size struct-type)


### PR DESCRIPTION
I'm creating this PR to suggest a change in CFFI.
I was having serious performance problems in an application I'm working on, but didn't implement.
The application uses cl-gtk2-gtk.
The problem I was having was that my mouse events were producing so much output into the REPL that it was unusable, and it looked like some events were getting lost.  I'm not 100% sure anything was actually getting lost but because of the volumes of repeated style warnings, the system was unusable.

I commented out this style warning, and it make the program much more responsive.

It is not clear to me why I get the style warning 1000s of times.  It could be that my program is doing some sort of run-time compilation or evaluation.  As I said I didn't write the program, just starting working on it.