### PR TITLE
Add support for C99 _Bool

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -1940,6 +1940,11 @@ default.
 (convert-from-foreign 1 :boolean) @result{} t
 @end lisp
 
+@ForeignType{:bool}
+
+The @code{:bool} type represents the C99 @code{_Bool} or C++
+@code{bool}. Its size is usually 1 byte except on OSX where it's an @code{int}.
+
 @ForeignType{:wrapper base-type &key to-c from-c}
 
 The @code{:wrapper} type stores two symbols passed to the @var{to-c}

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -986,6 +986,10 @@ The buffer has dynamic extent and may be stack allocated."
       (not (zerop (eval value)))
       `(not (zerop ,value))))
 
+;;; Boolean type that represents C99 _Bool
+(defctype :bool (:boolean #+darwin :int
+                          #-darwin :char))
+
 ;;;# Typedefs for built-in types.
 
 (defctype :uchar  :unsigned-char)

--- a/tests/libtest.c
+++ b/tests/libtest.c
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <float.h>
+#include <stdbool.h>
 
 /* MSVC doesn't have stdint.h and uses a different syntax for stdcall */
 #ifndef _MSC_VER
@@ -287,6 +288,24 @@ DLLEXPORT
 unsigned long bool_xor(long a, unsigned long b)
 {
     return (a && !b) || (!a && b);
+}
+
+DLLEXPORT
+unsigned sizeof_bool(void)
+{
+    return (unsigned)sizeof(_Bool);
+}
+
+DLLEXPORT
+unsigned bool_to_unsigned(_Bool b)
+{
+    return (unsigned)b;
+}
+
+DLLEXPORT
+_Bool unsigned_to_bool(unsigned u)
+{
+    return (_Bool)u;
 }
 
 /*

--- a/tests/misc-types.lisp
+++ b/tests/misc-types.lisp
@@ -86,6 +86,43 @@
           (bool-xor nil nil))
   (t t t t nil t nil))
 
+(defcfun "sizeof_bool" :unsigned-int)
+
+(deftest misc-types.sizeof.bool
+    (sizeof-bool)
+  #.(foreign-type-size :bool))
+
+(defcfun "bool_to_unsigned" :unsigned-int
+  (b :bool))
+
+(defcfun "unsigned_to_bool" :bool
+  (u :unsigned-int))
+
+(deftest misc-types.bool.convert-to-foreign.mem
+    (loop :for v :in '(nil t)
+          :collect
+          (with-foreign-object (b :bool)
+            (setf (mem-ref b :bool) v)
+            (mem-ref b #.(cffi::canonicalize-foreign-type :bool))))
+  (0 1))
+
+(deftest misc-types.bool.convert-to-foreign.call
+    (loop :for v :in '(nil t)
+          :collect (bool-to-unsigned v))
+  (0 1))
+
+(deftest misc-types.bool.convert-from-foreign.mem
+    (loop :for v :in '(0 1 42)
+          :collect
+          (with-foreign-object (b :bool)
+            (setf (mem-ref b #.(cffi::canonicalize-foreign-type :bool)) v)
+            (mem-ref b :bool)))
+  (nil t t))
+
+(deftest misc-types.bool.convert-from-foreign.call
+    (loop :for v :in '(0 1 42)
+          :collect (unsigned-to-bool v))
+  (nil t t))
 
 ;;; Regression test: boolean type only worked with canonicalized
 ;;; built-in integer types. Should work for any type that canonicalizes


### PR DESCRIPTION
Hard-coding the size is one more hack that will work on i386/x86_64 but I'm not sure about other architectures. Better support for ABIs is necessary, which would probably mean that the backends would stop deferring to the host for standard type mappings.
At least there's the test suite.