### PR TITLE
Fix invoke to return output.

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -277,7 +277,9 @@ int main(int argc, char**argv) {
                     (format *debug-io* "~&Attempting to continue anyway.~%")
                     (return)))))
       (appendf *cc-flags*
-               (parse-command-flags (invoke "pkg-config" pkg "--cflags"))))))
+               (parse-command-flags (run-program (list "pkg-config" pkg "--cflags")
+                                                 :output :string
+                                                 :error-output :interactive))))))
 
 ;;; This form also has some "read time" effects. See GENERATE-C-FILE.
 (define-grovel-syntax in-package (name)


### PR DESCRIPTION
Commit 2de8ece51b20ec0da177f8e38febb3127b1dafc2 changed invoke so that
it didn't return the output of running the command. This broke
pkg-config-cflags because that needs the output of running the
pkg-config command. This fixes that problem.