### PR TITLE
fix :multiple enum union in a structure.

### DIFF
--- a/src/enum.lisp
+++ b/src/enum.lisp
@@ -127,7 +127,7 @@
         (translate-to-foreign value type)))
 
 (defmethod translate-from-foreign (value (type foreign-enum))
-  (%foreign-enum-keyword type value :errorp t))
+  (%foreign-enum-keyword type value :errorp nil))
 
 (defmethod expand-to-foreign (value (type foreign-enum))
   (once-only (value)


### PR DESCRIPTION
I have the following structure to covert:
```c
typedef struct cs_arm_op {
	int vector_index;	// Vector Index for some vector operands (or -1 if irrelevant)
	struct {
		arm_shifter type;
		unsigned int value;
	} shift;
	arm_op_type type;	// operand type
	union {
		unsigned int reg;	// register value for REG/SYSREG operand
		int32_t imm;			// immediate value for C-IMM, P-IMM or IMM operand
		double fp;			// floating point value for FP operand
		arm_op_mem mem;		// base/index/scale/disp value for MEM operand
		arm_setend_type setend; // SETEND instruction's operand type
	};
	// in some instructions, an operand can be subtracted or added to
	// the base register,
	bool subtracted; // if TRUE, this operand is subtracted. otherwise, it is added.
} cs_arm_op;
```
you can noticed that the union members "reg", "imm", "fp", "mem", "setend".
when I want to convert such structure form c to lisp, it will raise exception to say that, for example, "4033 is not of type arm_setend_type", which arm_setend_type is a enum type.

Of course it is true when the actual used field in union is not "setend".

I made such change to by pass this exception, but it should be a bug of cffi and should have a better solution, so merge my solution or give out a better one.

Thanks very much!
 

