### PR TITLE
Fix foreign-slot-set compiler macro expansion.

### DIFF
--- a/src/types.lisp
+++ b/src/types.lisp
@@ -582,7 +582,7 @@ The foreign array must be freed with foreign-array-free."
 
 (defmethod foreign-struct-slot-set-form (value ptr (slot aggregate-struct-slot))
   "Return a form to get the value of an aggregate SLOT relative to PTR."
-  `(setf (foreign-struct-slot-value ,ptr ',(slot-name slot)) ,value))
+  `(setf (foreign-struct-slot-value ,ptr ,slot) ,value))
 
 ;;;## Defining Foreign Structures
 


### PR DESCRIPTION
When trying to setf aggregated slot value using `(setf foreign-slot-value)` with constant type and slot name
```lisp
 (setf (cffi:foreign-slot-value decoded '(:struct amqp-queue-declare-t) 'queue) (cffi:convert-to-foreign queue-bytes '(:struct amqp-bytes-t)))
```

 the following error signaled:

```
There is no applicable method for the generic function
  #<STANDARD-GENERIC-FUNCTION
    (COMMON-LISP:SETF CFFI::FOREIGN-STRUCT-SLOT-VALUE) (2)>
when called with arguments
  (#.(SB-SYS:INT-SAP #X7FFB58C6F0B0)
   #.(SB-SYS:INT-SAP #X7FFC5FB0FFB8) QUEUE).
```

I don't know much about cffi internals but I believe proposed change fixes this issue and hopefully doesn't break things