### PR TITLE
Fix read macro probromatic in ARM CPU.

### DIFF
--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -76,7 +76,6 @@
   #+arm '("-marm")
   #+arm64 '()
   #-(or arm arm64)
-  #-arm
   (ecase (cffi:foreign-type-size :pointer)
     (4 '("-m32"))
     (8 '("-m64"))))


### PR DESCRIPTION
This removes read macro written twice, which causes problem on ARM environment, like raspberry pi.

I ran into this problem in

 - implementation: SBCL 1.3.4,
 - hardware: on raspberry pi Type B 512MB (with ARM 32 bit CPU),
 - OS: Raspbian 8.0

while loading CFFI, with the following error message:
```
; caught ERROR:
;   READ error during COMPILE-FILE: unmatched close parenthesisLine: 82, Column: 19, File-Position: 2874Stream: #<SB-INT:FORM-TRACKING-STREAM for "file /home/pi/.roswell/impls/ALL/ALL/quicklisp/dists/quicklisp/software/cffi_0.17.1/toolchain/c-toolchain.lisp" {53760711}>
While evaluating the form starting at line 6, column 0
  of #P"/home/pi/.roswell/impls/ALL/ALL/quicklisp/dists/quicklisp/software/static-vectors-1.6/static-vectors.asd":
Unhandled LOAD-SYSTEM-DEFINITION-ERROR: Error while trying to load definition for system static-vectors from pathname /home/pi/.roswell/impls/ALL/ALL/quicklisp/dists/quicklisp/software/static-vectors-1.6/static-vectors.asd: COMPILE-FILE-ERROR while compiling #<CL-SOURCE-FILE "cffi-toolchain" "toolchain" "c-toolchain">
```
