### PR TITLE
Remove duplicate entries from *cc-flags*

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -281,8 +281,13 @@ int main(int argc, char**argv) {
           (run-program program+args
                        :output (make-broadcast-stream output-stream *debug-io*)
                        :error-output output-stream)
-          (appendf *cc-flags*
-                   (parse-command-flags (get-output-stream-string output-stream))))
+          (setf *cc-flags* 
+                (nreverse 
+                 (remove-duplicates 
+                  (append (parse-command-flags 
+                           (get-output-stream-string output-stream))
+                          (nreverse *cc-flags*))
+                  :test #'string=))))
       (error (e)
         (let ((message (format nil "~a~&~%~a~&"
                                e (get-output-stream-string output-stream))))

--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -33,7 +33,8 @@
 ;;; Utils
 
 (defun parse-command-flags (flags)
-  (remove-if 'emptyp (split-string flags :separator '(#\Space #\Tab #\Newline))))
+  (let ((separators '(#\Space #\Tab #\Newline #\Return)))
+    (remove-if 'emptyp (split-string flags :separator separators))))
 
 (defun parse-command-flags-list (strings)
   (loop for flags in strings append (parse-command-flags flags)))

--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -33,8 +33,7 @@
 ;;; Utils
 
 (defun parse-command-flags (flags)
-  (let ((separators '(#\Space #\Tab #\Newline #\Return)))
-    (remove-if 'emptyp (split-string flags :separator separators))))
+  (remove-if 'emptyp (split-string flags :separator '(#\Space #\Tab #\Newline))))
 
 (defun parse-command-flags-list (strings)
   (loop for flags in strings append (parse-command-flags flags)))


### PR DESCRIPTION
From commit message:

`define-grovel-syntax pkg-config-cflags' would add the same paths even
if they were already in *cc-flags*.

The modified code appends the new flags, and then removes the
duplicates.  The new flags are placed at the end of *cc-flags*