### PR TITLE
parse-command-flags: Added #\Return to separators

### DIFF
--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -33,7 +33,8 @@
 ;;; Utils
 
 (defun parse-command-flags (flags)
-  (remove-if 'emptyp (split-string flags :separator '(#\Space #\Tab #\Newline))))
+  (let ((separators '(#\Space #\Tab #\Newline #\Return)))
+    (remove-if 'emptyp (split-string flags :separator separators))))
 
 (defun parse-command-flags-list (strings)
   (loop for flags in strings append (parse-command-flags flags)))


### PR DESCRIPTION
On Windows7+MSYS, the output of pkg-config as read by CCL included
\#RETURN.

I added #\Return the bag of separators.  I also reformatted the code a
bit, to make it a bit more readable (fewer long lines or ackward line
splits).