### PR TITLE
use lisp-namespace for enabling documentation

### DIFF
--- a/cffi.asd
+++ b/cffi.asd
@@ -36,7 +36,8 @@
   :author "James Bielman  <jamesjb@jamesjb.com>"
   :maintainer "Luis Oliveira  <loliveira@common-lisp.net>"
   :licence "MIT"
-  :depends-on (:uiop :alexandria :trivial-features :babel)
+  :depends-on (:uiop :alexandria :trivial-features :babel
+                     :lisp-namespace)
   :in-order-to ((test-op (load-op :cffi-tests)))
   :perform (test-op (o c) (operate 'asdf:test-op :cffi-tests))
   :components

--- a/src/cffi-clisp.lisp
+++ b/src/cffi-clisp.lisp
@@ -269,7 +269,7 @@ takes care of converting the calling convention names."
   (flet ((find-cffi-symbol (symbol)
            (find-symbol (symbol-name symbol) '#:cffi)))
     `(,(find-cffi-symbol '#:foreign-library-handle)
-       (,(find-cffi-symbol '#:get-foreign-library) ',name))))
+       (,(find-cffi-symbol '#:symbol-foreign-library) ',name))))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   ;; version 2.40 (CVS 2006-09-03, to be more precise) added a

--- a/src/foreign-vars.lisp
+++ b/src/foreign-vars.lisp
@@ -46,7 +46,7 @@
    name (if (eq library :default)
             :default
             (foreign-library-handle
-             (get-foreign-library library)))))
+             (symbol-foreign-library library)))))
 
 (defun fs-pointer-or-lose (foreign-name library)
   "Like foreign-symbol-ptr but throws an error instead of

--- a/src/functions.lisp
+++ b/src/functions.lisp
@@ -80,7 +80,7 @@
            (or convention
                (when libraryp
                  (let ((lib-options (foreign-library-options
-                                     (get-foreign-library library))))
+                                     (symbol-foreign-library library))))
                    (getf lib-options :convention)))
                :cdecl)
            ;; Don't pass the library option if we're dealing with

--- a/tests/misc.lisp
+++ b/tests/misc.lisp
@@ -92,7 +92,7 @@
 ;;; when the need arises.
 (deftest library.t-clause
     (eq (cffi::foreign-library-spec
-         (cffi::get-foreign-library 'pseudo-library))
+         (cffi::symbol-foreign-library 'pseudo-library))
         'pseudo-library-spec)
   t)
 


### PR DESCRIPTION
This makes define-foreign-library to accept (:documentation "str"). May require the next quicklisp release.