### PR TITLE
ecl: defcallback: fix calling-convention

### DIFF
--- a/src/cffi-ecl.lisp
+++ b/src/cffi-ecl.lisp
@@ -401,9 +401,11 @@ WITH-POINTER-TO-VECTOR-DATA."
 (defmacro %defcallback (name rettype arg-names arg-types body
                         &key convention)
   (declare (ignore convention))
-  (let ((cb-name (intern-callback name)))
+  (let ((cb-name (intern-callback name))
+        (cb-type #.(if (> ext:+ecl-version-number+ 160102)
+                       :default :cdecl)))
     `(progn
-       (ffi:defcallback (,cb-name :cdecl)
+       (ffi:defcallback (,cb-name ,cb-type)
            ,(cffi-type->ecl-type rettype)
            ,(mapcar #'list arg-names
                     (mapcar #'cffi-type->ecl-type arg-types))


### PR DESCRIPTION
This is for bytecmp and the C compiler compatibility. :cdecl doesn't
work on Android, but :default works just fine. For C compiled code there
is no difference.

This patch will trigger itself on the upcoming ECL release (16.1.3) and is backward-compatible. Tested with cffi-tests – no regressions found (both with "fake" 16.1.3 version of ECL and 16.1.2).