### PR TITLE
don't depend on uiop if in sbcl, because sbcl already loads it.

### DIFF
--- a/cffi.asd
+++ b/cffi.asd
@@ -36,7 +36,8 @@
   :author "James Bielman  <jamesjb@jamesjb.com>"
   :maintainer "Luis Oliveira  <loliveira@common-lisp.net>"
   :licence "MIT"
-  :depends-on (:uiop :alexandria :trivial-features :babel)
+  :depends-on ( #-sbcl :uiop
+               :alexandria :trivial-features :babel)
   :components
   ((:module "src"
     :serial t


### PR DESCRIPTION
I'm taking out the explicit dependency on :uiop for sbcl because sbcl already loads it anyway
and including it causes lots of uiop functions to get needlessly redefined polluting startup with
volumes of useless warning messages.