### PR TITLE
cffi-abcl: fix foreign-alloc/foreign-free

### DIFF
--- a/src/cffi-abcl.lisp
+++ b/src/cffi-abcl.lisp
@@ -230,12 +230,12 @@
   (defun %foreign-alloc (size)
     "Allocate SIZE bytes on the heap and return a pointer."
     (make-pointer
-     (jcall-raw malloc-jmethod nil size))))
+     (jstatic-raw malloc-jmethod nil size))))
 
 (let ((free-jmethod (private-jmethod "com.sun.jna.Memory" "free")))
   (defun foreign-free (ptr)
     "Free a PTR allocated by FOREIGN-ALLOC."
-    (jcall-raw free-jmethod nil (%pointer-address ptr))
+    (jstatic-raw free-jmethod nil (%pointer-address ptr))
     nil))
 
 ;;; TODO: stack allocation.


### PR DESCRIPTION
Recent change to jna in ABCL causes breakage of CFFI. Patch provided by
ferada.