### PR TITLE
system: re-add dependency on UIOP as :require

### DIFF
--- a/cffi.asd
+++ b/cffi.asd
@@ -36,7 +36,7 @@
   :author "James Bielman  <jamesjb@jamesjb.com>"
   :maintainer "Luis Oliveira  <loliveira@common-lisp.net>"
   :licence "MIT"
-  :depends-on (:alexandria :trivial-features :babel)
+  :depends-on (:uiop :alexandria :trivial-features :babel)
   :in-order-to ((test-op (load-op :cffi-tests)))
   :perform (test-op (o c) (operate 'asdf:test-op :cffi-tests))
   :components


### PR DESCRIPTION
Dependency on `uiop' can't be implicit for sake of `program-op' and
`image-op' builds. User may wish to not include `asdf' or `cmp' (in case
of ECL) in the final image.

ASDF has option (require-system :system) which doesn't reload it, if
it's already present in the image (even if it's newer):

https://common-lisp.net/project/asdf/asdf.html#index-require_002dsystem

so (:require :uiop) shouldn't reload the system. That said, ASDF doesn't
handler (:require :system-name) options correclty yet, treating them
like normal dependencies. But this will be forward-compatible when ASDF
will fix that.

Closes #96.