### PR TITLE
add ffi-export-predicate

### DIFF
--- a/src/c2ffi/asdf.lisp
+++ b/src/c2ffi/asdf.lisp
@@ -52,6 +52,8 @@
                          :initform 'default-ffi-name-transformer)
    (ffi-type-transformer :initarg :ffi-type-transformer
                          :initform 'default-ffi-type-transformer)
+   (ffi-export-predicate :initarg :ffi-export-predicate
+                         :initform 'default-ffi-export-predicate)
    (foreign-library-name :initarg :foreign-library-name
                          :initform nil)
    (foreign-library-spec :initarg :foreign-library-spec
@@ -173,6 +175,7 @@ file, except that it's will be stored in the fasl cache."))
              (loop
                :for arg :in '(ffi-name-transformer
                               ffi-type-transformer
+                              ffi-export-predicate
                               foreign-library-name
                               foreign-library-spec
                               emit-generated-name-mappings


### PR DESCRIPTION
This allows the user to provide a predicate to determine which of the generated symbols will be exported from the cffi/c2ffi specified package.

By default no symbols are exported (so that the current behaviour is maintained)

The predicate is specified in same the fashion as :ffi-type-transformer & :ffi-name-transformer

```
    :ffi-export-predicate "test-c2ffi.ffi::ffi-export-predicate"
```

The predicate function has the following form

```
(defun ffi-export-predicate (symbol)
  (alexandria:starts-with-subseq "NK-" (symbol-name symbol)))
```

We also switch to using `uiop`'s `define-package` so that using `asdf:load-system :force t` doesnt throw errors when it hits `defpackage`