### PR TITLE
Add caching of grovel & wrap results

### DIFF
--- a/cffi-grovel.asd
+++ b/cffi-grovel.asd
@@ -32,10 +32,12 @@
   :licence "MIT"
   :components
   ((:module "grovel"
+    :serial t
     :components
     ((:static-file "common.h")
      (:file "package")
-     (:file "grovel" :depends-on ("package"))
-     (:file "asdf" :depends-on ("grovel"))))))
+     (:file "feature-caching-read")
+     (:file "grovel")
+     (:file "asdf")))))
 
 ;; vim: ft=lisp et

--- a/grovel/asdf.lisp
+++ b/grovel/asdf.lisp
@@ -75,7 +75,7 @@
 ;;;# ASDF component: GROVEL-FILE
 
 (defclass grovel-file (process-op-input cc-flags-mixin)
-  ()
+  ((cache-dir :initform nil :initarg :cache-dir :accessor cache-dir-of))
   (:default-initargs
    :generated-lisp-file-type "processed-grovel-file")
   (:documentation
@@ -86,22 +86,25 @@
   (let* ((input-file (first (input-files op c)))
          (output-file (make-pathname :type (generated-lisp-file-type c)
                                      :defaults input-file))
-         (c-file (make-c-file-name output-file "__grovel")))
+         (c-file (make-c-file-name output-file "__grovel"))
+         (exe-file (make-exe-file-name c-file)))
     (list output-file
           c-file
-          (make-exe-file-name c-file))))
+          exe-file)))
+
 
 (defmethod perform ((op process-op) (c grovel-file))
-  (let* ((output-file (first (output-files op c)))
-         (input-file (first (input-files op c)))
-         (tmp-file (process-grovel-file input-file output-file)))
-    (rename-file-overwriting-target tmp-file output-file)))
+  (destructuring-bind (output-file c-file exe-file) (output-files op c)
+    (let* ((input-file (first (input-files op c)))
+           (absolute-cache-dir (absolute-cache-dir input-file (cache-dir-of c))))
+      (process-grovel-file* input-file output-file c-file exe-file absolute-cache-dir))))
 
 
 ;;;# ASDF component: WRAPPER-FILE
 
 (defclass wrapper-file (process-op-input cc-flags-mixin)
-  ((soname :initform nil :initarg :soname :accessor soname-of))
+  ((soname :initform nil :initarg :soname :accessor soname-of)
+   (cache-dir :initform nil :initarg :cache-dir :accessor cache-dir-of))
   (:default-initargs
    :generated-lisp-file-type "processed-wrapper-file")
   (:documentation
@@ -120,9 +123,10 @@
                                      :defaults input-file))
          (c-file (make-c-file-name output-file "__wrapper"))
          (o-file (make-o-file-name output-file "__wrapper"))
-         (lib-soname (wrapper-soname c)))
+         (lib-soname (wrapper-soname c))
+         (lib-file (make-lib-file-name (make-soname lib-soname output-file))))
     (list output-file
-          (make-lib-file-name (make-soname lib-soname output-file))
+          lib-file
           c-file
           o-file)))
 
@@ -135,19 +139,23 @@
         (multiple-value-bind (files translatedp) (call-next-method)
           (values (append files (list lib-file o-file)) translatedp)))))
 
+(defun absolute-cache-dir (input-file cache-dir)
+  (when cache-dir
+    (let ((input-dir (uiop:pathname-directory-pathname input-file)))
+      (uiop:ensure-directory-pathname
+       (uiop:subpathname input-dir cache-dir)))))
+
 (defmethod perform ((op process-op) (c wrapper-file))
-  (let* ((output-file (first (output-files op c)))
-         (input-file (first (input-files op c)))
-         (tmp-file (process-wrapper-file
-                    input-file
-                    :output-defaults output-file
-                    :lib-soname (wrapper-soname c))))
-      (unwind-protect
-           (alexandria:copy-file tmp-file output-file :if-to-exists :supersede)
-        (delete-file tmp-file))))
+  (destructuring-bind (output-file lib-name c-file o-file) (output-files op c)
+    (let* ((input-file (first (input-files op c)))
+           (absolute-cache-dir (absolute-cache-dir input-file (cache-dir-of c))))
+      (process-wrapper-file
+       input-file
+       output-file lib-name c-file o-file
+       :lib-soname (wrapper-soname c)
+       :absolute-cache-dir absolute-cache-dir))))
 
 
 ;; Allow for naked :grovel-file and :wrapper-file in asdf definitions.
 (setf (find-class 'asdf::cffi-grovel-file) (find-class 'grovel-file))
 (setf (find-class 'asdf::cffi-wrapper-file) (find-class 'wrapper-file))
-

--- a/grovel/feature-caching-read.lisp
+++ b/grovel/feature-caching-read.lisp
@@ -1,0 +1,78 @@
+;;;; -*- Mode: lisp; indent-tabs-mode: nil -*-
+;;;
+;;; grovel.lisp --- The CFFI Groveller.
+;;;
+;;; Copyright (C) 2005-2006, Dan Knap <dankna@accela.net>
+;;; Copyright (C) 2005-2006, Emily Backes <lucca@accela.net>
+;;; Copyright (C) 2007, Stelian Ionescu <sionescu@cddr.org>
+;;; Copyright (C) 2007, Luis Oliveira <loliveira@common-lisp.net>
+;;;
+;;; Permission is hereby granted, free of charge, to any person
+;;; obtaining a copy of this software and associated documentation
+;;; files (the "Software"), to deal in the Software without
+;;; restriction, including without limitation the rights to use, copy,
+;;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;;; of the Software, and to permit persons to whom the Software is
+;;; furnished to do so, subject to the following conditions:
+;;;
+;;; The above copyright notice and this permission notice shall be
+;;; included in all copies or substantial portions of the Software.
+;;;
+;;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;;; NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+;;; HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+;;; WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;;; DEALINGS IN THE SOFTWARE.
+;;;
+
+(in-package #:cffi-grovel)
+
+(defun dirty-featurep (x)
+  "Ugly in implementation but will always match the implementations logic"
+  (with-standard-io-syntax
+    (with-input-from-string (s (format nil "#+~s t" x))
+      (read s nil nil))))
+
+(defun make-caching-reader-conditional ()
+  (let ((cache (make-array 0 :adjustable t :fill-pointer 0)))
+    (list (lambda (stream sub-char numarg)
+	    (declare (ignore numarg))
+	    (let* ((feature-expr (let ((*package* (find-package :keyword))
+				       (*read-suppress* nil))
+				   (read stream t nil t)))
+		   (present (dirty-featurep feature-expr))
+		   (match (char= sub-char (if present #\+ #\-))))
+	      (vector-push-extend feature-expr cache)
+	      (if match
+		  (read stream t nil t)
+		  (let ((*read-suppress* t))
+		    (read stream t nil t)
+		    (values)))))
+	  cache)))
+
+(defun flatten-features (cache)
+  (let ((feature-expressions (concatenate 'list cache))
+        (ignored '(:or :and or and nil t))
+        (features nil))
+    (labels ((make-pairs (x) (list x (dirty-featurep x)))
+             (feature? (x) (and (keywordp x) (not (member x ignored))))
+             (dummy-walk (x)
+               (when (feature? x) (push x features))
+               nil))
+      (subst-if nil #'dummy-walk feature-expressions)
+      (mapcar #'make-pairs
+              (sort (remove-duplicates (remove-if-not #'keywordp features))
+                    #'string<)))))
+
+(defun call-with-cached-reader-conditionals (func &rest args)
+  (destructuring-bind (rfunc cache) (make-caching-reader-conditional)
+    (let ((*readtable* (copy-readtable)))
+      (set-dispatch-macro-character #\# #\+ rfunc *readtable*)
+      (set-dispatch-macro-character #\# #\- rfunc *readtable*)
+      (values (apply func args) (flatten-features cache)))))
+
+(defmacro with-cached-reader-conditionals (&body body)
+  `(call-with-cached-reader-conditionals (lambda () ,@body)))

--- a/grovel/package.lisp
+++ b/grovel/package.lisp
@@ -29,6 +29,7 @@
    ;; Class name
    #:grovel-file
    #:process-grovel-file
+   #:process-grovel-file*
    #:wrapper-file
    #:process-wrapper-file
    ;; Error conditions


### PR DESCRIPTION
So the goal is to be able to load the wrapper & .so files from a cache
rather than having to build them on every person's platform.

The interesting thing about the groveller is that we are allowed to put
reader conditionals (#+ & #-) in the wrapper specification. This means
that a cached result is only relevent if all the results of all the
conditionals match. To find out the required features (feature-set) we
wrap the specification loading in a with-cached-reader-conditionals
form.

So now if you specify a :cache-dir for a :soname wrapper the system
will now check for the existance of a feature specific folder within
cache-dir. If that dir exists it will copy .so and wrappers files to
the destination folder rather than making the c lib.

The name of the 'feature specific folder' we talked about above is
generated from the feature-set we talked about above (see note on cache
name below)

When loading from cache we use #'touch-file on the c-file and
o-file that would have been generated. This is to stop the warning that
results from annoucing a file in #'output-files and not creating it.

## Cache Name

As mentioned above we need a feature specfic name for the cache. To do
this we take the following:

- (or (uiop:operating-system) (software-type))
- (or (uiop:architecture) (machine-type))
- the features referenced by the reader conditionals in the spec file
  these are concatenated and hashed

And the we concatenate them into a string as follows

    (format nil "~a_~a_~x" os architecture hashed-features)

This works well except for the fact that it doesnt capture the
distinctions between different versions of the OS (e.g. win7 v win8). It
would be great to add a function to get that and then replace `os` with
that string.

## Side Note

So before we had code which generated the names of the output files
in the #'output-files method and then generated the names again for
the code doing the work.

This was just asking for bugs and was a waste of work so we now
destructure the names from #'output-files in the #'perform methods and
pass these names to the various worker functions

However this new version of `#'process-grovel-file` has a different
signature which could cause problems with backwards compatibility. To
that end I have named the new version `process-grovel-file*` and
redefined the old `process-grovel-file` to call the new one.