### PR TITLE
Add ffi-form-generators feature to c2ffi

### DIFF
--- a/src/c2ffi/asdf.lisp
+++ b/src/c2ffi/asdf.lisp
@@ -54,8 +54,8 @@
                          :initform 'default-ffi-type-transformer)
    (ffi-export-predicate :initarg :ffi-export-predicate
                          :initform 'default-ffi-export-predicate)
-   (ffi-form-generators :initarg :ffi-form-generators
-                        :initform nil)
+   (ffi-form-generator :initarg :ffi-form-generator
+                        :initform 'default-ffi-form-generator)
    (foreign-library-name :initarg :foreign-library-name
                          :initform nil)
    (foreign-library-spec :initarg :foreign-library-spec
@@ -178,7 +178,7 @@ file, except that it's will be stored in the fasl cache."))
                :for arg :in '(ffi-name-transformer
                               ffi-type-transformer
                               ffi-export-predicate
-                              ffi-form-generators
+                              ffi-form-generator
                               foreign-library-name
                               foreign-library-spec
                               emit-generated-name-mappings

--- a/src/c2ffi/asdf.lisp
+++ b/src/c2ffi/asdf.lisp
@@ -54,6 +54,8 @@
                          :initform 'default-ffi-type-transformer)
    (ffi-export-predicate :initarg :ffi-export-predicate
                          :initform 'default-ffi-export-predicate)
+   (ffi-form-generators :initarg :ffi-form-generators
+                        :initform nil)
    (foreign-library-name :initarg :foreign-library-name
                          :initform nil)
    (foreign-library-spec :initarg :foreign-library-spec
@@ -176,6 +178,7 @@ file, except that it's will be stored in the fasl cache."))
                :for arg :in '(ffi-name-transformer
                               ffi-type-transformer
                               ffi-export-predicate
+                              ffi-form-generators
                               foreign-library-name
                               foreign-library-spec
                               emit-generated-name-mappings

--- a/src/c2ffi/asdf.lisp
+++ b/src/c2ffi/asdf.lisp
@@ -54,8 +54,8 @@
                          :initform 'default-ffi-type-transformer)
    (ffi-export-predicate :initarg :ffi-export-predicate
                          :initform 'default-ffi-export-predicate)
-   (ffi-form-generator :initarg :ffi-form-generator
-                        :initform 'default-ffi-form-generator)
+   (ffi-plugin-factory :initarg :ffi-plugin-factory
+                        :initform 'default-ffi-plugin-factory)
    (foreign-library-name :initarg :foreign-library-name
                          :initform nil)
    (foreign-library-spec :initarg :foreign-library-spec
@@ -178,7 +178,7 @@ file, except that it's will be stored in the fasl cache."))
                :for arg :in '(ffi-name-transformer
                               ffi-type-transformer
                               ffi-export-predicate
-                              ffi-form-generator
+                              ffi-plugin-factory
                               foreign-library-name
                               foreign-library-spec
                               emit-generated-name-mappings

--- a/src/c2ffi/generator.lisp
+++ b/src/c2ffi/generator.lisp
@@ -57,7 +57,7 @@
 ;; Called on the CFFI type, e.g. to turn (:pointer :char) into a :string.
 (defvar *ffi-type-transformer* 'default-ffi-type-transformer)
 (defvar *ffi-export-predicate* 'default-ffi-export-predicate)
-(defvar *ffi-form-generator* 'default-ffi-form-generator)
+(defvar *ffi-plugin-factory* 'default-ffi-plugin-factory)
 
 (define-constant +generated-file-header+
     ";;; -*- Mode: lisp -*-~%~
@@ -293,9 +293,8 @@
             cffi-name))
     cffi-name))
 
-(defun default-ffi-form-generator (definition &key &allow-other-keys)
-  (declare (ignore definition))
-  nil)
+(defun default-ffi-plugin-factory (&key &allow-other-keys)
+  (values))
 
 (defun default-ffi-name-transformer (name kind &key &allow-other-keys)
   (check-type name string)
@@ -344,16 +343,6 @@
   (if (camelcased? name)
       (camelcase-to-dash-separated name)
       name))
-
-(defun possibly-generate-additional-form (definition-form generator-context)
-  (when (and *ffi-form-generator* generator-context)
-    (let* ((*print-readably* nil))
-      (multiple-value-bind (new-form dedup-key)
-          (call-hook *ffi-form-generator* definition-form)
-        (when new-form
-          (if dedup-key
-              (setf (gethash dedup-key generator-context) new-form)
-              (output/code new-form)))))))
 
 (defun default-ffi-export-predicate (symbol &key &allow-other-keys)
   (declare (ignore symbol))
@@ -514,7 +503,7 @@
                                   ;; as per CFFI:DEFINE-FOREIGN-LIBRARY and CFFI:LOAD-FOREIGN-LIBRARY
                                   (ffi-type-transformer *ffi-type-transformer*)
                                   (ffi-export-predicate *ffi-export-predicate*)
-                                  (ffi-form-generator *ffi-form-generator*)
+                                  (ffi-plugin-factory *ffi-plugin-factory*)
                                   foreign-library-name
                                   foreign-library-spec
                                   (emit-generated-name-mappings t)
@@ -558,8 +547,7 @@ target package."
                (*ffi-name-transformer* (canonicalize-transformer-hook ffi-name-transformer))
                (*ffi-type-transformer* (canonicalize-transformer-hook ffi-type-transformer))
                (*ffi-export-predicate* (canonicalize-transformer-hook ffi-export-predicate))
-               (*ffi-form-generator* (canonicalize-transformer-hook ffi-form-generator))
-               (ffi-generator-context (make-hash-table :test #'equal))
+               (*ffi-plugin-factory* (canonicalize-transformer-hook ffi-plugin-factory))
                (json (json:decode-json in)))
           (output/string +generated-file-header+)
           ;; some forms that are always emitted
@@ -588,27 +576,37 @@ target package."
                                        :element-type 'character)))
             ((or symbol function)
              (funcall prelude 'output/code)))
-          (dolist (json-entry json)
-            (with-json-values (json-entry name location)
-              (let ((source-location-file (subseq location
-                                                  0
-                                                  (or (position #\: location)
-                                                      0))))
-                (if (include-definition?
-                     name source-location-file
-                     include-definitions exclude-definitions
-                     include-sources exclude-sources)
-                    (progn
-                      (output/string "~&~%;; ~S" location)
-                      (process-c2ffi-entry json-entry ffi-generator-context))
-                    (output/string "~&;; Skipped ~S due to filters" name)))))
-          ;;
-          ;; emit deduped generated forms
-          (maphash
-           (lambda (key form)
-             (declare (ignore key))
-             (output/code form))
-           ffi-generator-context)
+
+          (multiple-value-bind (every-form-plugin after-forms-plugin)
+              (funcall *ffi-plugin-factory*)
+            (dolist (json-entry json)
+              (with-json-values (json-entry name location)
+                (let ((source-location-file (subseq location
+                                                    0
+                                                    (or (position #\: location)
+                                                        0))))
+                  (if (include-definition?
+                       name source-location-file
+                       include-definitions exclude-definitions
+                       include-sources exclude-sources)
+                      (progn
+                        (output/string "~&~%;; ~S" location)
+                        (let ((emitted-definition (process-c2ffi-entry json-entry every-form-plugin)))
+                          ;;
+                          ;; Call the plugin to let the user emit a form after the given
+                          ;; definition
+                          (when (and emitted-definition every-form-plugin)
+                            (let ((generated-code (call-hook every-form-plugin emitted-definition)))
+                              (when generated-code
+                                (output/code generated-code))))))
+                      (output/string "~&;; Skipped ~S due to filters" name)))))
+            ;;
+            ;; Call the plugin to let the user append multiple forms after the
+            ;; emitted definitions
+            (when after-forms-plugin
+              (let ((generated-code (call-hook after-forms-plugin)))
+                (when generated-code
+                  (map nil #'output/code (remove nil generated-code))))))
 
           ;;
           ;; emit optional exports
@@ -617,6 +615,7 @@ target package."
              (output/export (sort (remove-if-not #'should-export-p symbols) #'string<)
                             package-name))
            (get-all-names-by-package *generated-names*))
+
           ;;
           ;; emit optional mappings
           (when emit-generated-name-mappings
@@ -654,7 +653,7 @@ target package."
 
 (defvar *c2ffi-entry-processors* (make-hash-table :test 'equal))
 
-(defun process-c2ffi-entry (json-entry &optional generator-context)
+(defun process-c2ffi-entry (json-entry &optional every-form-plugin)
   (let* ((kind (json-value json-entry :tag))
          (processor (gethash kind *c2ffi-entry-processors*)))
     (if processor
@@ -672,10 +671,8 @@ target package."
                        (return-from process-c2ffi-entry (values)))))
                  (funcall processor json-entry))))
           (when definition-form
-            (output/code definition-form))
-          (when generator-context
-            (possibly-generate-additional-form definition-form generator-context))
-          definition-form)
+            (output/code definition-form)
+            definition-form))
         (progn
           (warn "No cffi/c2ffi processor defined for ~A" json-entry)
           (values)))))

--- a/src/c2ffi/package.lisp
+++ b/src/c2ffi/package.lisp
@@ -49,5 +49,4 @@
    #:change-case-to-readtable-case
    #:camelcased?
    #:camelcase-to-dash-separated
-   #:maybe-camelcase-to-dash-separated
-   #:context-data))
+   #:maybe-camelcase-to-dash-separated))

--- a/src/c2ffi/package.lisp
+++ b/src/c2ffi/package.lisp
@@ -49,4 +49,5 @@
    #:change-case-to-readtable-case
    #:camelcased?
    #:camelcase-to-dash-separated
-   #:maybe-camelcase-to-dash-separated))
+   #:maybe-camelcase-to-dash-separated
+   #:context-data))


### PR DESCRIPTION
The goal of this feature is to enable people to emit their own code
based on the generated form.

To use this you specify one or more generator forms using the
`:ffi-form-generators` key in your `:cffi/c2ffi-file` component.

For example:

```
:ffi-form-generators ((:defcstruct "raw-bindings-nuklear.ffi::ffi-generator-struct"))
```

This means that for every `cffi:defcstruct` form that is written to the
generated file `raw-bindings-nuklear.ffi::ffi-generator-struct` will be
called. Whatever form is returned from that function will be written
into the generated file using `#'output/code`.

The first element of the form (:defcstruct in the above case) is called
the 'pattern' and the second is the 'generator function'.

You can define multiple generator forms:

```
:ffi-form-generators ((:defcstruct "raw-bindings-nuklear.ffi::ffi-generator-struct")
                      (:defcunion "raw-bindings-nuklear.ffi::ffi-generator-union"))
```

It is legal to have both call the same function if you like.

These are the valid patterns you can use in your generator forms:

```
:defcfun
:defcstruct
:defcunion
:defctype
:defcvar
:defbitfield
:defcenum
:begin
:end
```

A generator function using the `:begin` pattern will be called once,
just before the c2ffi entries are processed

A generator function using the `:begin` pattern will be called once,
just after the c2ffi entries are processed

The signature for your generator function should be as follows:

```
(defun your-function (definition context &key &allow-other-keys)
  ...)
```

The context argument will be an instance of the `ffi-generator-context`
class. This object has one field called data, it has an accessor called
`#'context-data`.

The context exists for cases where you want to aggregate data during the
processing, usually with the goal of emitting it at the `:end`.

This can be useful when you want to make sure you don't emit forms for
duplicate definitions of cffi types. For example you may want to emit an
accessor function for cetain CFFI structs, however SBCL will throw an
error if it finds duplicate `defun`s in the same file

Here is an example of how this feature can be used. The goal is to emit
a `defstruct` form for every `cffi:defcstruct`.

In the asd file:

```
:ffi-form-generators ((:begin "raw-bindings-nuklear.ffi::ffi-generator-begin")
                  (:defcstruct "raw-bindings-nuklear.ffi::ffi-generator-struct")
                  (:end "raw-bindings-nuklear.ffi::ffi-generator-end"))
```

In a auxilary lisp file:

```
;; we make a hash table to store and deduplicate the defstruct forms
(defun ffi-generator-begin (definition context &key &allow-other-keys)
  (declare (ignore definition))
  (setf (context-data context) (make-hash-table :test #'equal))
  nil)

;; For each defcstruct we make a defstruct form and store it in the
;; context
(defun ffi-generator-struct (definition context &key &allow-other-keys)
  (destructuring-bind (name-and-options . fields) (rest definition)
    (destructuring-bind (name . options) (uiop:ensure-list name-and-options)
      (declare (ignore options))
      (when fields
        (let* ((wrapper-name-str (format nil "~a-WRAPPER" name))
               (wrapper-name (intern wrapper-name-str)))
          (setf (gethash `(:struct ,name) (context-data context))
                `(defstruct ,wrapper-name ,@(mapcar #'first fields)))))))
  nil)

;; We emit all the defstruct forms
(defun ffi-generator-end (definition context &key &allow-other-keys)
  (declare (ignore definition))
  (let ((data (context-data context)))
    `(progn
       ,@(loop :for k :being :the :hash-keys :of data :collect
            (gethash k data)))))
```

This feature is slightly more open ended than the other :ffi-*
transformer and export forms, however I feels it's flexibility worth the
small cost in difficulty.
