### PR TITLE
better error for in-package grovelling

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -802,8 +802,12 @@ string."
     (process-wrapper-form out form)))
 
 (define-wrapper-syntax in-package (name)
-  (setq *package* (find-package name))
-  (push `(in-package ,name) *lisp-forms*))
+  (let ((desired-package (find-package name)))
+    (assert desired-package ()
+            "Wrapper file specified (in-package ~s)~%however that does not name a known package"
+            name)
+    (setq *package* desired-package)
+    (push `(in-package ,name) *lisp-forms*)))
 
 (define-wrapper-syntax c (&rest strings)
   (dolist (string strings)

--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -802,10 +802,10 @@ string."
     (process-wrapper-form out form)))
 
 (define-wrapper-syntax in-package (name)
+  (assert (find-package name) (name)
+          "Wrapper file specified (in-package ~s)~%however that does not name a known package."
+          name)
   (let ((desired-package (find-package name)))
-    (assert desired-package ()
-            "Wrapper file specified (in-package ~s)~%however that does not name a known package"
-            name)
     (setq *package* desired-package)
     (push `(in-package ,name) *lisp-forms*)))
 


### PR DESCRIPTION
Before the error was along the lines of `nil is not a package` which made it a little harder to track down which declaration was incorrect