### PR TITLE
Null name shouldnt satisfy strong rules

### DIFF
--- a/src/c2ffi/generator.lisp
+++ b/src/c2ffi/generator.lisp
@@ -123,12 +123,12 @@
   (labels
       ((covered-by-a-rule? (name rules)
          (or (eq rules :all)
-             (null name)
              (not (null (some (rcurry #'funcall name) rules)))))
        (weak? (rules)
          (eq :all rules))
        (strong? (name rules)
-         (and (not (weak? rules))
+         (and name
+              (not (weak? rules))
               (covered-by-a-rule? name rules))))
     (let* ((excl-def/weak   (weak? exclude-definitions))
            (excl-def/strong (strong? name exclude-definitions))


### PR DESCRIPTION
The problem with this that with forms like this:

    typedef enum {
      dJointTypeNone = 0,
      dJointTypeBall,
      dJointTypeHinge,
    } dJointType;

The enum is always excluded, as the name is nil. Then the `dJointType`
typedef tries too lookup the anonomous entry for the enum and fails.

The only way to counter it is to have explicitly include the definitions
for everything in the files (which makes it feel much less automatic).

This commit is one possible fix. Another is to allow the user to
customize the `include-definition?` predicate. Also `cl-autowrap`
handles this case so maybe we can take some inspiration from there.

The worrying thing of course is that this is a potentially breaking change