### PR TITLE
*read-default-float-format* should be double-float

### DIFF
--- a/src/c2ffi/generator.lisp
+++ b/src/c2ffi/generator.lisp
@@ -543,6 +543,7 @@ target package."
                (*ffi-name-transformer* (canonicalize-transformer-hook ffi-name-transformer))
                (*ffi-type-transformer* (canonicalize-transformer-hook ffi-type-transformer))
                (*ffi-export-predicate* (canonicalize-transformer-hook ffi-export-predicate))
+               (*read-default-float-format* 'double-float)
                (json (json:decode-json in)))
           (output/string +generated-file-header+)
           ;; some forms that are always emitted


### PR DESCRIPTION
Otherwise it crashes the first time it tries to read one. The example
case for me was in:

    #define DBL_EPSILON __DBL_EPSILON__