### PR TITLE
Fixed loading in LispWorks 6.1 / ASDF 2.26

### DIFF
--- a/cffi.asd
+++ b/cffi.asd
@@ -38,7 +38,6 @@
   :licence "MIT"
   :depends-on (:uiop :alexandria :trivial-features :babel)
   :in-order-to ((test-op (load-op :cffi-tests)))
-  :perform (test-op (o c) (operate 'asdf:test-op :cffi-tests))
   :components
   ((:module "src"
     :serial t
@@ -71,7 +70,8 @@
 ;; so we assume it satisfies any version requirements whatsoever.
 (defmethod version-satisfies ((c (eql (find-system :cffi))) version)
   (declare (ignorable version))
-  (or (null (component-version c))
+  (or (not (slot-boundp c 'version))
+      (null (component-version c))
       (call-next-method)))
 
 (defsystem :cffi/c2ffi


### PR DESCRIPTION
Hi,

Recent CFFI cannot load in LispWorks 6.1 (ASDF 2.26, the default version in Quicklisp). First of all, I don't really understand the purpose of this line:

:perform (test-op (o c) (operate 'asdf:test-op :cffi-tests))

But LispWorks 6.1 shows the following strange error:

CL-USER 1 > (asdf:load-system :cffi)
; Loading text file /Users/binghe/Lisp/cffi/cffi.asd

Error: Error while trying to load definition for system cffi from pathname /Users/binghe/Lisp/cffi/cffi.asd:
          (OPERATE (QUOTE TEST-OP) :CFFI-TESTS) does not match (O C).
  1 (continue) Try loading /Users/binghe/Lisp/cffi/cffi.asd again.
  2 Give up loading /Users/binghe/Lisp/cffi/cffi.asd.
  3 Try loading another file instead of /Users/binghe/Lisp/cffi/cffi.asd.
  4 Retry finding system cffi after reinitializing the source-registry.
  5 (abort) Return to level 0.
  6 Return to top loop level 0.

Type :b for backtrace or :c <option number> to proceed.
Type :bug-form "<subject>" for a bug report template or :? for other options.

ASDF 2 : 1 > :b
Call to ERROR
Call to (HARLEQUIN-COMMON-LISP:SUBFUNCTION 1 LOAD-SYSDEF)
Call to SIGNAL
Call to ERROR
Call to DSPEC::DESTRUCTURATION-ERROR
Call to DSPEC::DESTRUCTURATION-WRONG-NUM-ARGS-ERROR
Call to %DEFINE-COMPONENT-INLINE-METHODS
Call to PARSE-COMPONENT-FORM
Call to DO-DEFSYSTEM
Call to APPLY
Call to EVAL
Call to (HARLEQUIN-COMMON-LISP:SUBFUNCTION 1 LOAD)
Call to LOAD
Call to (HARLEQUIN-COMMON-LISP:SUBFUNCTION 1 LOAD-SYSDEF)
Call to (HARLEQUIN-COMMON-LISP:SUBFUNCTION 1 (METHOD FIND-SYSTEM (STRING)))
Call to (HARLEQUIN-COMMON-LISP:SUBFUNCTION 1 (METHOD OPERATE (T T)))
Call to CALL-WITH-SYSTEM-DEFINITIONS
Call to (METHOD OPERATE (T T))
Call to CLOS::GENERIC-FUNCTION-NON-DISCRIMINATOR
Call to LOAD-SYSTEM
Call to EVAL
Call to CAPI::CAPI-TOP-LEVEL-FUNCTION
Call to CAPI::INTERACTIVE-PANE-TOP-LOOP
Call to MP::PROCESS-SG-FUNCTION

Second, in old version of ASDF, the "version" slot doesn't have a default value (NIL), instead, it's unbounded if you don't specify a version for your ASDF system. So (null (component-version c)) test will cause the following error:

CL-USER 11 > (asdf:load-system :cffi)

Error: The slot ASDF:VERSION is unbound in the object #<ASDF:SYSTEM "cffi"> (an instance of class #<STANDARD-CLASS ASDF:SYSTEM 416009E0F3>).
  1 (continue) Try reading slot ASDF:VERSION again.
  2 Specify a value to use this time for slot ASDF:VERSION.
  3 Specify a value to set slot ASDF:VERSION to.
  4 (abort) Return to level 0.
  5 Return to top loop level 0.

Type :b for backtrace or :c <option number> to proceed.
Type :bug-form "<subject>" for a bug report template or :? for other options.

CL-USER 12 : 1 > :b
Call to ERROR
Call to (METHOD SLOT-UNBOUND (T T T))
Call to CLOS::CALL-SLOT-UNBOUND-FUNCTION
Interpreted call to (METHOD ASDF:VERSION-SATISFIES ((EQL (ASDF:FIND-SYSTEM :CFFI)) T))
Call to (SUBFUNCTION 1 (METHOD ASDF:OPERATE (T T)))
Call to ASDF::CALL-WITH-SYSTEM-DEFINITIONS
Call to (METHOD ASDF:OPERATE (T T))
Call to CLOS::GENERIC-FUNCTION-NON-DISCRIMINATOR
Call to ASDF:LOAD-SYSTEM
Call to EVAL
Call to CAPI::CAPI-TOP-LEVEL-FUNCTION
Call to CAPI::INTERACTIVE-PANE-TOP-LOOP
Call to MP::PROCESS-SG-FUNCTION

Using SLOT-BOUNDP could resolved this issue and make all ASDF versions happy.
