### PR TITLE
Fix dependencies in cffi-toolchain.asd

### DIFF
--- a/cffi-toolchain.asd
+++ b/cffi-toolchain.asd
@@ -35,11 +35,10 @@
   :licence "MIT"
   :components
   ((:module "toolchain"
-    :serial t
     :components
-    ((:file "package")
-     (:file "asdf-compat" :if-feature (#.(if (version<= "3.1.6" (asdf-version)) :or :and)))
-     (:file "c-toolchain")
-     (:file "static-link")))))
+    ((:file "asdf-compat" :if-feature (#.(if (version<= "3.1.6" (asdf-version)) :or :and)))
+     (:file "package")
+     (:file "c-toolchain" :depends-on ("package"))
+     (:file "static-link" :depends-on ("asdf-compat" "c-toolchain"))))))
 
 ;; vim: ft=lisp et


### PR DESCRIPTION
The dependencies were subtly wrong: when the ASDF loaded was already > 3.1.6,
then the asdf-compat was blackholed by its if-feature condition,
which broke the chain of dependencies for package.