### PR TITLE
Fix dynamic linking with SB-LINKABLE-RUNTIME

### DIFF
--- a/grovel/asdf.lisp
+++ b/grovel/asdf.lisp
@@ -146,8 +146,7 @@
            (alexandria:copy-file tmp-file output-file :if-to-exists :supersede)
         (delete-file tmp-file))))
 
-
-;; Allow for naked :grovel-file and :wrapper-file in asdf definitions.
+;; Allow for naked :cffi-grovel-file and :cffi-wrapper-file in asdf definitions.
 (setf (find-class 'asdf::cffi-grovel-file) (find-class 'grovel-file))
 (setf (find-class 'asdf::cffi-wrapper-file) (find-class 'wrapper-file))
 

--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -248,7 +248,7 @@ is bound to a temporary file name, then atomically renaming that temporary file 
 
 (defun cc-compile (output-file inputs)
   (apply 'invoke-builder (list *cc* "-o") output-file
-         "-c" #-windows "-fPIC" (append *cc-flags* inputs)))
+         "-c" (append *cc-flags* #-windows '("-fPIC") inputs)))
 
 (defun link-executable (output-file inputs)
   (apply 'invoke-builder (list *ld* "-o") output-file
@@ -354,7 +354,7 @@ is bound to a temporary file name, then atomically renaming that temporary file 
 (defmethod perform ((o compile-op) (c c-file))
   (let ((i (first (input-files o c))))
     (destructuring-bind (.o .so) (output-files o c)
-      (cc-compile .o (list #-windows "-fPIC" i))
+      (cc-compile .o (list i))
       (link-shared-library .so (list .o)))))
 
 (defmethod perform ((o load-op) (c c-file))


### PR DESCRIPTION
Shared objects were failing to link on the latest SBCL because it specifies
-fno-pie in its CFLAGS, but that invalidates the previously specified -fPIC.
Fix that by specifying -fPIC *after* the SBCL-provided CFLAGS, not *before*.

Also, remove a redundant use of -fPIC, and fix a comment.