### PR TITLE
append a url link to the corresponding manual page to each docstring …

### DIFF
--- a/cffi.asd
+++ b/cffi.asd
@@ -36,7 +36,7 @@
   :author "James Bielman  <jamesjb@jamesjb.com>"
   :maintainer "Luis Oliveira  <loliveira@common-lisp.net>"
   :licence "MIT"
-  :depends-on (:uiop :alexandria :trivial-features :babel)
+  :depends-on (:uiop :alexandria :trivial-features :babel :split-sequence)
   :in-order-to ((test-op (load-op :cffi-tests)))
   :perform (test-op (o c) (operate 'asdf:test-op :cffi-tests))
   :components
@@ -65,7 +65,8 @@
      (:file "structures")
      (:file "functions")
      (:file "foreign-vars")
-     (:file "features")))))
+     (:file "features")
+     (:file "doc"))))
 
 ;; when you get CFFI from git, its defsystem doesn't have a version,
 ;; so we assume it satisfies any version requirements whatsoever.

--- a/src/doc.lisp
+++ b/src/doc.lisp
@@ -1,0 +1,26 @@
+
+(in-package :cffi)
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defun append-url (sym doc-type)
+    (setf (documentation sym doc-type)
+          (with-output-to-string (s)
+            (princ (documentation sym doc-type) :stream s)
+            ;; do the same name-normalization as texinfo
+            (format s "~2% Detailed documentation: ~
+                        https://common-lisp.net/project/cffi/manual/html_node/~{~a~^_002d~}.html"
+                    (split-sequence:split-sequence #\- (string-downcase (symbol-name sym)))))))
+
+  (do-external-symbols (sym :cffi)
+    (cond
+      ((documentation sym 'variable)
+       (append-url sym 'variable))
+      ((documentation sym 'function)
+       (append-url sym 'function))
+      ((documentation sym 'type)
+       (append-url sym 'type))
+      ((documentation sym 'structure)
+       (append-url sym 'structcture))
+      ((documentation sym 'method-combination)
+       (append-url sym 'method-combination)))))
+


### PR DESCRIPTION
…of exported symbols

A little hack for improving the manual accessibility (w/o requiring additional emacs customization such as extended hyperspec-lookup)