### PR TITLE
defcunion and defcstruct supports nested structs/unions

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -2663,8 +2663,16 @@ type, such as @code{:long} or @code{:pointer}.  Used for simple
 @cffi{} types.
 
 @item Aggregate
-Contain an embedded structure or union, or an array of objects.  Used
-for aggregate @cffi{} types.
+Contain an embedded structure or union, or an array of objects, such
+as @code{(:struct my-struct)}, @code{(:struct my-union)}. Used for
+aggregate @cffi{} types. To represent an array of objects, use the
+@code{:count} keyword.
+
+Slot types also support nested @cffi{} struct/union types a.l.a C,
+when the CDR of the type specifier is a list of slot descriptions.
+A temporary type name in a form of ``@code{name}/@code{slot-name}'' is
+given to the internally nested union/struct.
+See examples below.
 @end table
 
 The use of @acronym{CLOS} terminology for the structure-related
@@ -2711,6 +2719,39 @@ CFFI> (foreign-type-size 'foo)
 (defcstruct video_tuner
   (name :char :count 32))
 @end lisp
+
+
+@lisp
+;; @lispcmt{An example of using a nested union.}
+;; @lispcmt{This code defines two structures: dd-node (for the entire}
+;; @lispcmt{struct) and dd-node/type (for the nested union).}
+
+(defcstruct dd-node
+  (index dd-half-word)
+  (ref   dd-half-word)
+  (next  (:pointer (:struct dd-node)))
+  (type  (:union
+           ; @lispcmt{Since :union is followed by a list,}
+           ; @lispcmt{ this is parsed as a nested union.}
+           (value cudd-value-type)
+           (kids dd-children))))
+@end lisp
+
+This is equivalent to the C code below:
+
+@example
+/* Example from CUDD library (http://vlsi.colorado.edu/%7Efabio/CUDD/html/structDdNode.html) */
+struct DdNode @{
+    DdHalfWord index;		/**< variable index */
+    DdHalfWord ref;		/**< reference count */
+    DdNode *next;		/**< next pointer for unique table */
+    union @{
+	CUDD_VALUE_TYPE value;	/**< for constant (terminal) nodes */
+	DdChildren kids;	/**< for internal nodes */
+    @} type;			/**< terminal or internal */
+@};
+@end example
+
 
 @subheading See Also
 @seealso{foreign-slot-pointer} @*

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -946,11 +946,14 @@ slots will be defined and stored."
   (destructuring-bind (name &key size)
       (ensure-list name-and-options)
     (declare (ignore size))
-    `(eval-when (:compile-toplevel :load-toplevel :execute)
-       (notice-foreign-union-definition ',name-and-options ',fields)
-       (define-parse-method ,name ()
-         (parse-deprecated-struct-type ',name :union))
-       '(:union ,name))))
+    (let (*nested-structs*)
+      (setf fields (mapcar (lambda (field) (parse-substructure name field)) fields))
+      `(eval-when (:compile-toplevel :load-toplevel :execute)
+         ,@*nested-structs*
+         (notice-foreign-union-definition ',name-and-options ',fields)
+         (define-parse-method ,name ()
+           (parse-deprecated-struct-type ',name :union))
+         '(:union ,name)))))
 
 ;;;# Operations on Types
 

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -722,15 +722,36 @@ The foreign array must be freed with foreign-array-free."
 
 (defvar *defcstruct-hook* nil)
 
+(defvar *nested-structs*)
+(defun parse-substructure (parent field)
+  (destructuring-bind (name type &rest options) field
+    (when (atom type)
+      (return-from parse-substructure field))
+    (destructuring-bind (head &rest subfields) type
+      (unless (member head '(:struct :union))
+        (return-from parse-substructure field))
+      (when (and (= 1 (length subfields))
+                 (atom (car subfields)))
+        (return-from parse-substructure field))
+      (let ((anontype (symbolicate parent '/ name))
+            (macro (ecase head
+                     (:struct 'defcstruct)
+                     (:union  'defcunion))))
+        (push `(,macro ,anontype ,@subfields) *nested-structs*)
+        `(,name (,head ,anontype) ,@options)))))
+
 (defmacro defcstruct (name-and-options &body fields)
   "Define the layout of a foreign structure."
   (discard-docstring fields)
   (destructuring-bind (name . options)
       (ensure-list name-and-options)
-    (let ((conc-name (getf options :conc-name)))
+    (let ((conc-name (getf options :conc-name))
+          *nested-structs*)
       (remf options :conc-name)
       (unless (getf options :class) (setf (getf options :class) (symbolicate name '-tclass)))
+      (setf fields (mapcar (lambda (field) (parse-substructure name field)) fields))
       `(eval-when (:compile-toplevel :load-toplevel :execute)
+         ,@*nested-structs*
          ;; m-f-s-t could do with this with mop:ensure-class.
          ,(when-let (class (getf options :class))
             `(defclass ,class (foreign-struct-type


### PR DESCRIPTION
https://www.google.co.jp/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&ved=0ahUKEwig9KKVoOPSAhXEVrwKHauECWMQFggcMAA&url=http%3A%2F%2Fstackoverflow.com%2Fquestions%2F14047845%2Fnested-structs-and-unions-with-common-lisp-cffi&usg=AFQjCNE7miVq7Aau35TVipCPn9nLqxpIHQ&sig2=VvBugFNKFzlzuxoN13h6bg&cad=rja

This change does not affect the original semantics of `(:union union-name)` and `(:struct struct-name)`.
Sub-structs/unions are recognized when the cdr of the type form is a list.
See the documentation for an example.