### PR TITLE
variadic functions: promote as interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ SBCL     ?= sbcl
 CLISP    ?= clisp
 ALLEGRO  ?= alisp
 SCL      ?= scl
+ECL      ?= ecl
 
 shlibs:
 	@$(MAKE) -wC tests shlibs
@@ -63,6 +64,9 @@ test-clisp-modern:
 test-allegro:
 	@-$(ALLEGRO) -L tests/run-tests.lisp
 
-test: test-openmcl test-sbcl test-cmucl test-clisp
+test-ecl:
+	@-$(ECL) --quiet --load tests/run-tests.lisp
+
+test: test-openmcl test-sbcl test-cmucl test-clisp test-ecl
 
 # vim: ft=make ts=3 noet

--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -432,10 +432,6 @@ On platforms where ECL's dynamic FFI is not supported (ie. when
 @code{:dffi} is not present in @code{*features*}),
 @code{cffi:load-foreign-library} does not work and you must use ECL's
 own @code{ffi:load-foreign-library} with a constant string argument.
-@item
-Does not support the @code{:long-long} type natively.
-@item
-Unicode support is not enabled by default.
 @end itemize
 
 @subheading Lispworks

--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -5257,6 +5257,8 @@ Dictionary
 * defcfun::
 * foreign-funcall::
 * foreign-funcall-pointer::
+* foreign-funcall-varargs::
+* foreign-funcall-pointer-varargs::
 * translate-camelcase-name::
 * translate-name-from-foreign::
 * translate-name-to-foreign::
@@ -5500,7 +5502,7 @@ CFFI> (foreign-funcall "printf" :string (format nil "%s: %d.~%")
 @c FOREIGN-FUNCALL-POINTER
 
 @page
-@node foreign-funcall-pointer,  translate-camelcase-name, foreign-funcall, Functions
+@node foreign-funcall-pointer, foreign-funcall-varargs, foreign-funcall, Functions
 @heading foreign-funcall-pointer
 @subheading Syntax
 @Macro{foreign-funcall-pointer pointer options &rest arguments @res{} return-value}
@@ -5559,12 +5561,118 @@ CFFI> (foreign-funcall-pointer (foreign-symbol-pointer "abs") ()
 @seealso{defcfun} @*
 @seealso{foreign-funcall}
 
+@c ===================================================================
+@c FOREIGN-FUNCALL-VARARGS
+
+@page
+@node foreign-funcall-varargs, foreign-funcall-pointer-varargs, foreign-funcall-pointer, Functions
+@heading foreign-funcall-varargs
+@subheading Syntax
+@Macro{foreign-funcall-varargs name-and-options (fixed-arguments) &rest arguments @res{} return-value}
+
+fixed-arguments ::= @{ arg-type arg @}* [return-type]
+arguments ::= @{ arg-type arg @}* [return-type]
+name-and-options ::= name | ( name &key library convention)
+
+@subheading Arguments and Values
+
+@table @var
+@item name
+A Lisp string.
+
+@item arg-type
+A foreign type.
+
+@item arg
+An argument of type @var{arg-type}.
+
+@item return-type
+A foreign type, @code{:void} by default.
+
+@item return-value
+A lisp object.
+
+@item library
+A lisp symbol; not evaluated.
+
+@item convention
+One of @code{:cdecl} (default) or @code{:stdcall}.
+@end table
+
+@subheading Description
+The @code{foreign-funcall-varargs} macro is the main primitive for
+calling foreign variadic functions. It behaves similarily to
+@code{foreign-funcall} except @code{fixed-arguments} are distinguished
+from the remaining arguments.
+
+@subheading Examples
+
+@lisp
+CFFI> (with-foreign-pointer-as-string (s 100)
+          (setf (mem-ref s :char) 0)
+          (foreign-funcall-varargs
+           "sprintf" (:pointer s :string "%.2f")
+           :double (coerce pi 'double-float) :int))
+@result{} 3.14
+@end lisp
+
+@c ===================================================================
+@c FOREIGN-FUNCALL-POINTER-VARARGS
+
+@page
+@node foreign-funcall-pointer-varargs, translate-camelcase-name, foreign-funcall-varargs, Functions
+@heading foreign-funcall-pointer-varargs
+@subheading Syntax
+@Macro{foreign-funcall-pointer-varargs pointer options (fixed-arguments) &rest arguments @res{} return-value}
+
+fixed-arguments ::= @{ arg-type arg @}* [return-type]
+arguments ::= @{ arg-type arg @}* [return-type]
+options ::= ( &key convention )
+
+@subheading Arguments and Values
+
+@table @var
+@item pointer
+A foreign pointer.
+
+@item arg-type
+A foreign type.
+
+@item arg
+An argument of type @var{arg-type}.
+
+@item return-type
+A foreign type, @code{:void} by default.
+
+@item return-value
+A lisp object.
+
+@item convention
+One of @code{:cdecl} (default) or @code{:stdcall}.
+@end table
+
+@subheading Description
+The @code{foreign-funcall-pointer-varargs} macro is the main primitive
+for calling foreign variadic functions. It behaves similarily to
+@code{foreign-funcall-pointer} except @code{fixed-arguments} are
+distinguished from the remaining arguments.
+
+@subheading Examples
+
+@lisp
+CFFI> (with-foreign-pointer-as-string (s 100)
+          (setf (mem-ref s :char) 0)
+          (foreign-funcall-pointer-varargs
+           (foreign-symbol-pointer "sprintf") () (:pointer s :string "%.2f")
+           :double (coerce pi 'double-float) :int))
+@result{} 3.14
+@end lisp
 
 @c ===================================================================
 @c TRANSLATE-CAMELCASE-NAME
 
 @page
-@node translate-camelcase-name, translate-name-from-foreign, foreign-funcall-pointer, Functions
+@node translate-camelcase-name, translate-name-from-foreign, foreign-funcall-pointer-varargs, Functions
 @heading translate-camelcase-name
 @subheading Syntax
 @Function{translate-camelcase-name name &key upper-initial-p special-words @res{} return-value}

--- a/doc/cffi-sys-spec.texinfo
+++ b/doc/cffi-sys-spec.texinfo
@@ -270,6 +270,26 @@ function, as returned by @code{foreign-symbol-pointer}, rather than a
 string @var{name}.
 @end defmac
 
+@defmac %foreign-funcall-varargs name (@{fixed-type arg@}*) @{vararg-type arg@}* &optional result-type @result{} object
+@defmacx %foreign-funcall-varargs-pointer ptr (@{fixed-type arg@}*) @{vararg-type arg@}* &optional result-type @result{} object
+Invoke a foreign variadic function called @var{name} in the foreign
+source code.
+
+Each @var{fixed-type} and @var{vararg-type} is a foreign type
+specifier, followed by @var{arg}, Lisp data to be converted to foreign
+data of type @var{arg-type}.  @var{result-type} is the foreign type of
+the function's return value, and is assumed to be @code{:void} if not
+supplied.
+
+@code{%foreign-funcall-pointer-varargs} takes a pointer @var{ptr} to
+the variadic function, as returned by @code{foreign-symbol-pointer},
+rather than a string @var{name}.
+
+Both functions have default implementation which call
+@code{%foreign-funcall} and @code{%foreign-funcall-pointer}
+approprietly.
+@end defmac
+
 @heading Examples
 
 @lisp

--- a/src/functions.lisp
+++ b/src/functions.lisp
@@ -150,6 +150,20 @@
     ((:unsigned-char :unsigned-short) :unsigned-int)
     (t builtin-type)))
 
+;; If cffi-sys doesn't provide a %foreign-funcall-varargs macros we
+;; define one that use %foreign-funcall.
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (unless (fboundp '%foreign-funcall-varargs)
+    (defmacro %foreign-funcall-varargs (name fixed-args varargs
+                                        &rest args &key convention library)
+      (declare (ignore convention library))
+      `(%foreign-funcall ,name ,(append fixed-args varargs) ,@args)))
+  (unless (fboundp '%foreign-funcall-pointer-varargs)
+    (defmacro %foreign-funcall-pointer-varargs (pointer fixed-args varargs
+                                                &rest args &key convention)
+      (declare (ignore convention))
+      `(%foreign-funcall-pointer ,pointer ,(append fixed-args varargs) ,@args))))
+
 (defun foreign-funcall-varargs-form (thing options fixed-args varargs pointerp)
   (multiple-value-bind (fixed-types fixed-ctypes fixed-fargs)
       (parse-args-and-types fixed-args)
@@ -162,18 +176,17 @@
          (append fixed-fargs varargs-fargs)
          (append fixed-types varargs-types)
          rettype
-         `(,(if pointerp '%foreign-funcall-pointer '%foreign-funcall)
+         `(,(if pointerp '%foreign-funcall-pointer-varargs '%foreign-funcall-varargs)
             ,thing
+            ,(mapcan #'list fixed-ctypes fixed-syms)
             ,(append
               (mapcan #'list
-                      (nconc fixed-ctypes
-                             (mapcar #'promote-varargs-type varargs-ctypes))
-                      (append fixed-syms
-                              (loop for sym in varargs-syms
-                                    and type in varargs-ctypes
-                                    if (eq type :float)
-                                    collect `(float ,sym 1.0d0)
-                                    else collect sym)))
+                      (mapcar #'promote-varargs-type varargs-ctypes)
+                      (loop for sym in varargs-syms
+                         and type in varargs-ctypes
+                         if (eq type :float)
+                         collect `(float ,sym 1.0d0)
+                         else collect sym))
               (list (canonicalize-foreign-type rettype)))
             ,@options))))))
 
@@ -183,6 +196,8 @@
 ;;; %foreign-funcall-varargs on some hypothetical lisp on an
 ;;; hypothetical platform that has different calling conventions for
 ;;; varargs functions. :-)
+;;;
+;;; -- indeed it is useful for ECL static FFI!
 (defmacro foreign-funcall-varargs (name-and-options fixed-args
                                    &rest varargs)
   "Wrapper around %FOREIGN-FUNCALL that translates its arguments

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -103,6 +103,8 @@
    #:defcfun
    #:foreign-funcall
    #:foreign-funcall-pointer
+   #:foreign-funcall-varargs
+   #:foreign-funcall-pointer-varargs
    #:translate-camelcase-name
    #:translate-name-from-foreign
    #:translate-name-to-foreign

--- a/tests/callbacks.lisp
+++ b/tests/callbacks.lisp
@@ -268,8 +268,8 @@
 
 (defcfun "call_sum_127_no_ll" :long (cb :pointer))
 
-;;; CMUCL, ECL and CCL choke on this one.
-#-(or ecl cmucl clozure
+;;; CMUCL and CCL choke on this one.
+#-(or cmucl clozure
       #.(cl:if (cl:>= cl:lambda-parameters-limit 127) '(:or) '(:and)))
 (defcallback sum-127-no-ll :long
     ((a1 :unsigned-long) (a2 :pointer) (a3 :long) (a4 :double)
@@ -326,7 +326,7 @@
           (format t "a~A: ~A~%" i arg))
     (reduce #'+ args)))
 
-#+(or openmcl cmucl ecl (and darwin (or allegro lispworks)))
+#+(or openmcl cmucl (and darwin (or allegro lispworks)))
 (push 'callbacks.bff.1 regression-test::*expected-failures*)
 
 #+#.(cl:if (cl:>= cl:lambda-parameters-limit 127) '(:and) '(:or))
@@ -341,8 +341,8 @@
 (progn
   (defcfun "call_sum_127" :long-long (cb :pointer))
 
-  ;;; CMUCL, ECL and CCL choke on this one.
-  #-(or cmucl ecl clozure)
+  ;;; CMUCL and CCL choke on this one.
+  #-(or cmucl clozure)
   (defcallback sum-127 :long-long
       ((a1 :short) (a2 :char) (a3 :pointer) (a4 :float) (a5 :long) (a6 :double)
        (a7 :unsigned-long-long) (a8 :unsigned-short) (a9 :unsigned-char)
@@ -393,7 +393,7 @@
        (values (floor a108)) a109 a110 a111 a112 a113 a114 a115 a116 a117 a118
        a119 a120 a121 (values (floor a122)) a123 a124 a125 a126 a127))
 
-  #+(or openmcl cmucl ecl)
+  #+(or openmcl cmucl)
   (push 'callbacks.bff.2 rt::*expected-failures*)
 
   (deftest callbacks.bff.2

--- a/tests/defcfun.lisp
+++ b/tests/defcfun.lisp
@@ -264,6 +264,20 @@
 
 ;;;# Calling varargs functions
 
+(defcfun "sum_double_arbitrary" :double (n :int) &rest)
+
+(deftest defcfun.varargs.nostdlib
+    (sum-double-arbitrary
+     26
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0)
+  81.64d0)
+
 (defcfun "sprintf" :int
   "sprintf docstring"
   (str (:pointer :char))

--- a/tests/enum.lisp
+++ b/tests/enum.lisp
@@ -50,7 +50,7 @@
   1)
 
 (defcenum another-boolean :false :true)
-(defcfun "return_enum" another-boolean (x :int))
+(defcfun "return_enum" another-boolean (x :uint))
 
 (deftest enum.2
     (and (eq :false (return-enum 0))

--- a/tests/funcall.lisp
+++ b/tests/funcall.lisp
@@ -104,6 +104,19 @@
 
 ;;;# Calling Varargs Functions
 
+(deftest funcall.varargs.nostdlib
+    (foreign-funcall-varargs
+     "sum_double_arbitrary" (:int 26)
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0 :double 3.14d0 :double 3.14d0
+     :double 3.14d0 :double 3.14d0
+     :double)
+  81.64d0)
+
 ;; The CHAR argument must be passed as :INT because chars are promoted
 ;; to ints when passed as variable arguments.
 (deftest funcall.varargs.char

--- a/tests/funcall.lisp
+++ b/tests/funcall.lisp
@@ -109,19 +109,23 @@
 (deftest funcall.varargs.char
     (with-foreign-pointer-as-string (s 100)
       (setf (mem-ref s :char) 0)
-      (foreign-funcall "sprintf" :pointer s :string "%c" :int 65 :int))
+      (foreign-funcall-varargs
+       "sprintf" (:pointer s :string "%c") :int 65 :int))
   "A")
 
 (deftest funcall.varargs.int
     (with-foreign-pointer-as-string (s 100)
       (setf (mem-ref s :char) 0)
-      (foreign-funcall "sprintf" :pointer s :string "%d" :int 1000 :int))
+      (foreign-funcall-varargs
+       "sprintf" (:pointer s :string "%d") :int 1000 :int))
   "1000")
 
 (deftest funcall.varargs.long
     (with-foreign-pointer-as-string (s 100)
       (setf (mem-ref s :char) 0)
-      (foreign-funcall "sprintf" :pointer s :string "%ld" :long 131072 :int))
+      (foreign-funcall-varargs
+       "sprintf" (:pointer s :string "%ld")
+       :long 131072 :int))
   "131072")
 
 ;;; There is no FUNCALL.VARARGS.FLOAT as floats are promoted to double
@@ -130,23 +134,23 @@
 (deftest funcall.varargs.double
     (with-foreign-pointer-as-string (s 100)
       (setf (mem-ref s :char) 0)
-      (foreign-funcall "sprintf" :pointer s :string "%.2f"
-                       :double (coerce pi 'double-float) :int))
+      (foreign-funcall-varargs
+       "sprintf" (:pointer s :string "%.2f") :double (coerce pi 'double-float) :int))
   "3.14")
 
 #+(and scl long-float)
 (deftest funcall.varargs.long-double
     (with-foreign-pointer-as-string (s 100)
       (setf (mem-ref s :char) 0)
-      (foreign-funcall "sprintf" :pointer s :string "%.2Lf"
-                       :long-double pi :int))
+      (foreign-funcall-varargs
+       "sprintf" :pointer s :string "%.2Lf" :long-double pi :int))
   "3.14")
 
 (deftest funcall.varargs.string
     (with-foreign-pointer-as-string (s 100)
       (setf (mem-ref s :char) 0)
-      (foreign-funcall "sprintf" :pointer s :string "%s, %s!"
-                       :string "Hello" :string "world" :int))
+      (foreign-funcall-varargs
+       "sprintf" (:pointer s :string "%s, %s!") :string "Hello" :string "world" :int))
   "Hello, world!")
 
 ;;; See DEFCFUN.DOUBLE26.

--- a/tests/libtest.c
+++ b/tests/libtest.c
@@ -38,6 +38,7 @@
 #include <math.h>
 #include <float.h>
 #include <stdbool.h>
+#include <stdarg.h>
 
 /* MSVC doesn't have stdint.h and uses a different syntax for stdcall */
 #ifndef _MSC_VER
@@ -838,6 +839,21 @@ double sum_double26(double a1, double a2, double a3, double a4, double a5,
     return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 +
         a14 + a15 + a16 + a17 + a18 + a19 + a20 + a21 + a22 + a23 + a24 + a25 +
         a26;
+}
+
+/*
+ * DEFCFUN.VARARGS.NOSTDLIB and FUNCALL.VARARGS.NOSTDLIB
+ */
+DLLEXPORT
+double sum_double_arbitrary(int n, ...)
+{
+    va_list ap;
+    double sum = 0;
+    va_start(ap, n);
+    for(int j=0; j<n; j++)
+      sum += va_arg(ap, double);
+    va_end(ap);
+    return sum;
 }
 
 /*

--- a/tests/memory.lisp
+++ b/tests/memory.lisp
@@ -427,8 +427,8 @@
 
 ;;; RT: FOREIGN-ALLOC with :COUNT 0 on CLISP signalled an error.
 (deftest foreign-alloc.10
-    (foreign-free (foreign-alloc :char :count 0))
-  nil)
+    (null (foreign-free (foreign-alloc :char :count 0)))
+  t)
 
 ;;; Tests for mem-ref with a non-constant type. This is a way to test
 ;;; the functional interface (without compiler macros).


### PR DESCRIPTION
Promote foreign-funcall-varargs and foreign-funcall-pointer-varargs as interface:

- export `foreign-funcall-varargs` and `foreign-funcall-pointer-varargs` from `cffi` package
- add `%foreign-funcall-varargs` implementation-specific interface (with default implementation falling back to `%foreign-funcall`) //  (same thing for `%foreign-funcall-pointer-varargs`)
- update vararg tests to use new interface
- update documentation (manual and spec texinfo files)

Motivation:

These interfaces were created with "hypotetical" scenario in mind when some implementation may need this information. It seems, that ECL when inlining calls to C functions needs this information.