### PR TITLE
Add &REST MAKE-ARRAY-ARGS to #'FOREIGN-ARRAY-TO-LISP

### DIFF
--- a/src/types.lisp
+++ b/src/types.lisp
@@ -388,7 +388,8 @@ newly allocated memory."
       form))
 
 (defun lisp-array-to-foreign (array pointer array-type)
-  "Copy elements from a Lisp array to POINTER."
+  "Copy elements from a Lisp array to POINTER. ARRAY-TYPE must be a CFFI array
+type."
   (let* ((type (ensure-parsed-base-type array-type))
          (el-type (element-type type))
          (dimensions (dimensions type)))
@@ -400,14 +401,15 @@ newly allocated memory."
                                (row-major-index-to-indexes i dimensions))
           do (setf (mem-ref pointer el-type offset) element))))
 
-(defun foreign-array-to-lisp (pointer array-type)
-  "Copy elements from ptr into a Lisp array. If POINTER is a null
-pointer, returns NIL."
+(defun foreign-array-to-lisp (pointer array-type &rest make-array-args)
+  "Copy elements from pointer into a Lisp array. ARRAY-TYPE must be a CFFI array
+type; the type of the resulting Lisp array can be defined in MAKE-ARRAY-ARGS
+that are then passed to MAKE-ARRAY. If POINTER is a null pointer, returns NIL."
   (unless (null-pointer-p pointer)
     (let* ((type (ensure-parsed-base-type array-type))
            (el-type (element-type type))
            (dimensions (dimensions type))
-           (array (make-array dimensions)))
+           (array (apply #'make-array dimensions make-array-args)))
       (loop with foreign-type-size = (array-element-size type)
             with size = (reduce #'* dimensions)
             for i from 0 below size


### PR DESCRIPTION
Rename test ARRAY.ROUND-TRIP to ARRAY.FOREIGN-TO-LISP.BASIC
Add test ARRAY.FOREIGN-TO-LISP.ADJUSTABLE
Add test ARRAY.FOREIGN-TO-LISP.DISPLACED
Add test ARRAY.FOREIGN-TO-LISP.SPECIALIZED

Implementation detail for test ARRAY.FOREIGN-TO-LISP.SPECIALIZED:

15.1.2.2 of the standard states that the only truly portable array specializations are for bits (bit-vectors) and characters (strings). Since char-codes are implementation-dependent, it would be tricky to write a portable test for them without generating characters at runtime. So, for a truly portable test, we are only left with bits, which are luckily numeric, and equal to (UNSIGNED-BYTE 1).

This is why this test is so terribly wasteful, spending a whole byte for a single bit - CFFI has no capabilities for dealing with single bits, and this test is only meant to check correctness of the :ELEMENT-TYPE argument to
MAKE-ARRAY. In actual use cases of specialized FOREIGN-ARRAY-TO-LISP, capable implementations will be able to make specialized arrays of types that are commonly optimized for and/or representable in hardware, such as (UNSIGNED-BYTE 8) on x86 architectures.