### PR TITLE
translate non-keyword foreign enum keys properly

### DIFF
--- a/src/enum.lisp
+++ b/src/enum.lisp
@@ -219,7 +219,7 @@
         (%foreign-enum-keyword type-obj value :errorp errorp))))
 
 (defmethod translate-to-foreign (value (type foreign-enum))
-  (if (keywordp value)
+  (if (symbolp value)
       (%foreign-enum-value type value :errorp t)
       value))
 
@@ -233,7 +233,7 @@
 
 (defmethod expand-to-foreign (value (type foreign-enum))
   (once-only (value)
-    `(if (keywordp ,value)
+    `(if (symbolp ,value)
          (%foreign-enum-value ,type ,value :errorp t)
          ,value)))
 


### PR DESCRIPTION
%foreign-enum-value accepts any non-NIL symbol, so don't limit it to
KEYWORDP in translate-to-foreign and expand-to-foreign.

Also fixes style-warning in SBCL when passing keywords to inlined
foreign function calls with SPEED 3.