### PR TITLE
Use sb-rt in sbcl instead of rt package

### DIFF
--- a/cffi-tests.asd
+++ b/cffi-tests.asd
@@ -52,7 +52,7 @@
 
 (defsystem "cffi-tests"
   :description "Unit tests for CFFI."
-  :depends-on ("cffi-grovel" "cffi-libffi" "bordeaux-threads" #-ecl "rt" #+ecl (:require "rt"))
+  :depends-on ("cffi-grovel" "cffi-libffi" "bordeaux-threads" #-(or ecl sbcl) "rt" #+sbcl (:require "sb-rt") #+ecl (:require "rt"))
   :components
   ((:module "tests"
     :components

--- a/tests/bindings.lisp
+++ b/tests/bindings.lisp
@@ -55,11 +55,11 @@
 (defmacro deftest (name &rest body)
   (destructuring-bind (name &key expected-to-fail)
       (alexandria:ensure-list name)
-    (let ((result `(rt:deftest ,name ,@body)))
+    (let ((result `(#-sbcl rt:deftest #+sbcl sb-rt:deftest ,name ,@body)))
       (when expected-to-fail
         (setf result `(progn
                         (when ,expected-to-fail
-                          (pushnew ',name rt::*expected-failures*))
+                          (pushnew ',name #-sbcl rt::*expected-failures* #+sbcl sb-rt::*expected-failures*))
                         ,result)))
       result)))
 
@@ -132,12 +132,12 @@
 (defcvar "double_min" :double)
 
 (defun run-cffi-tests (&key (compiled nil))
-  (let ((regression-test::*compile-tests* compiled)
+  (let ((#-sbcl regression-test::*compile-tests* #+sbcl sb-rt::*compile-tests*compiled)
         (*package* (find-package '#:cffi-tests)))
     (format t "~&;;; running tests (~Acompiled)" (if compiled "" "un"))
     (do-tests)
-    (set-difference (regression-test:pending-tests)
-                    regression-test::*expected-failures*)))
+    (set-difference (#-sbcl regression-test:pending-tests #+sbcl sb-rt:pending-tests)
+                    #-sbcl regression-test::*expected-failures* #+sbcl sb-rt::*expected-failures*)))
 
 (defun run-all-cffi-tests ()
   (append (run-cffi-tests :compiled nil)

--- a/tests/defcfun.lisp
+++ b/tests/defcfun.lisp
@@ -436,7 +436,7 @@
     (a121 :int) (a122 :float) (a123 :unsigned-char) (a124 :unsigned-char)
     (a125 :double) (a126 :unsigned-long-long) (a127 :char))
 
-  #+(and sbcl x86) (push 'defcfun.bff.2 rtest::*expected-failures*)
+  #+(and sbcl x86) (push 'defcfun.bff.2 sb-rt::*expected-failures*)
 
   (deftest defcfun.bff.2
       (sum-127

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -28,6 +28,6 @@
 (in-package #:cl-user)
 
 (defpackage #:cffi-tests
-  (:use #:cl #:cffi #:cffi-sys #:regression-test)
+  (:use #:cl #:cffi #:cffi-sys #-sbcl #:regression-test #+sbcl #:sb-rt)
   (:export #:do-tests #:run-cffi-tests #:run-all-cffi-tests)
   (:shadow #:deftest))

--- a/tests/random-tester.lisp
+++ b/tests/random-tester.lisp
@@ -36,7 +36,7 @@
 ;;; this code can generate.
 
 (defpackage #:cffi-random-tester
-  (:use #:cl #:cffi #:alexandria #:regression-test))
+  (:use #:cl #:cffi #:alexandria #-sbcl #:regression-test #+sbcl #:sb-rt))
 (in-package #:cffi-random-tester)
 
 (defstruct (c-type (:conc-name type-))

--- a/tests/strings.lisp
+++ b/tests/strings.lisp
@@ -83,7 +83,7 @@
   #.*ascii-test-bytes*)
 
 ;;; FIXME: bogus test. We need support for BOM or UTF-16{BE,LE}.
-(pushnew 'string.encoding.utf-16.basic rtest::*expected-failures*)
+(pushnew 'string.encoding.utf-16.basic #-sbcl rtest::*expected-failures* #+sbcl sb-rt::*expected-failures*)
 
 ;;; Test UTF-16 conversion of a string back and forth.  Tests proper
 ;;; null terminator handling for wide character strings and ensures no


### PR DESCRIPTION
SBCL provides a version of rt called sb-rt.