### PR TITLE
Evaluate :count, :size, :offset forms while creating 'defcstruct'.

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -2744,14 +2744,16 @@ CFFI> (foreign-type-size 'foo)
 @node defcunion, defctype, defcstruct, Foreign Types
 @heading defcunion
 @subheading Syntax
-@Macro{defcunion name &body doc-and-slots @res{} name}
+@Macro{defcunion name-and-options &body doc-and-slots @res{} name}
+
+name-and-options ::= union-name | (union-name &key size)
 
 doc-and-slots ::= [docstring] @{ (slot-name slot-type &key count) @}*
 
 @subheading Arguments and Values
 
 @table @var
-@item name
+@item union-name
 The name of new union type.
 
 @item docstring
@@ -2760,12 +2762,20 @@ A documentation string, ignored.
 @item slot-name
 A symbol naming the slot.
 
+@item size
+Use this option to override the size (in bytes) of the union.
+Can accept form that will be evaluated.
+Signals type-error when not evaluated to a non-negative integer.
+
 @item slot-type
 The type specifier for the slot.
 
 @item count
 Used to declare an array of size @var{count} inside the
-structure.
+union. Defaults to @code{1} as such an array and a single element
+are semantically equivalent.
+Can accept form that will be evaluated.
+Signals type-error when not evaluated to a positive integer.
 @end table
 
 @subheading Description

--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -2610,7 +2610,7 @@ CFFI> (unix-open "/tmp/foo" '(:wronly :creat) #o644)
 @subheading Syntax
 @Macro{defcstruct name-and-options &body doc-and-slots @res{} name}
 
-name-and-options ::= structure-name | (structure-name &key size)
+name-and-options ::= structure-name | (structure-name &key class size conc-name)
 
 doc-and-slots ::= [docstring] @{ (slot-name slot-type &key count offset) @}*
 
@@ -2627,8 +2627,20 @@ A documentation string, ignored.
 A symbol naming the slot.  It must be unique among slot names in this
 structure.
 
+@item class
+The class name of new structure type.
+Defaults to @code{'structure-name' + '-tclass'}.
+
 @item size
 Use this option to override the size (in bytes) of the struct.
+Can accept form that will be evaluated.
+Signals type-error when not evaluated to a non-negative integer.
+
+@item conc-name
+A symbol which is used to generate structure accessors(readers, writers).
+When this option is specified, accessor functions will be generated
+for each structure slot.
+The name of accessor functions would be equal to @code{'conc-name' + 'slot-name'}.
 
 @item slot-type
 The type specifier for the slot.
@@ -2637,10 +2649,14 @@ The type specifier for the slot.
 Used to declare an array of size @var{count} inside the
 structure.  Defaults to @code{1} as such an array and a single element
 are semantically equivalent.
+Can accept form that will be evaluated.
+Signals type-error when not evaluated to a positive integer.
 
 @item offset
 Overrides the slot's offset. The next slot's offset is calculated
 based on this one.
+Can accept form that will be evaluated.
+Signals type-error when not evaluated to a non-negative integer.
 @end table
 
 @subheading Description

--- a/src/early-types.lisp
+++ b/src/early-types.lisp
@@ -118,11 +118,10 @@ variables, functions, and typedefs) or :STRUCT (for structs, unions, and enums).
 ;;; of style warnings in SBCL.  (Silly reason, yes.)
 (defmacro define-parse-method (name lambda-list &body body)
   "Define a type parser on NAME and lists whose CAR is NAME."
-  (discard-docstring body)
   (warn-if-kw-or-belongs-to-cl name)
   `(eval-when (:compile-toplevel :load-toplevel :execute)
      (setf (find-type-parser ',name)
-           (lambda ,lambda-list ,@body))
+           (lambda ,lambda-list ,@(omit-docstring body)))
      ',name))
 
 ;;; Utility function for the simple case where the type takes no

--- a/src/enum.lisp
+++ b/src/enum.lisp
@@ -161,15 +161,15 @@
                    :value-keywords value-keywords)))
 
 (defun %defcenum-like (name-and-options enum-list type-factory)
-  (discard-docstring enum-list)
   (destructuring-bind (name &optional base-type)
       (ensure-list name-and-options)
-    (let ((type (funcall type-factory name base-type enum-list)))
+    (let* ((pure-enum-list (omit-docstring enum-list))
+           (type (funcall type-factory name base-type pure-enum-list)))
       `(eval-when (:compile-toplevel :load-toplevel :execute)
          (notice-foreign-type ',name
                               ;; ,type is not enough here, someone needs to
                               ;; define it when we're being loaded from a fasl.
-                              (,type-factory ',name ',base-type ',enum-list))
+                              (,type-factory ',name ',base-type ',pure-enum-list))
          ,@(remove nil
                    (mapcar (lambda (key)
                              (unless (keywordp key)

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -986,6 +986,21 @@ based on PREVIOUS-SLOT and slot parameters: NAME, TYPE, and COUNT."
         :size (* count (foreign-type-size type))
         :alignment (foreign-type-alignment type)))
 
+(defmacro expand-notice-foreign-union-definition (name class slot-defs size)
+  "Expand into `notice-foreign-type-definition' using
+a union NAME, CLASS, SLOT-DEFS and SIZE."
+  (with-unique-names (union-size union-alignment union-slots)
+    `(with-defined-slots (slots ,slot-defs union-slot-def->slot)
+       (let* ((,union-size ,(or size '(apply #'max 0
+                                       (%get-slots-prop slots :size))))
+              (,union-alignment (apply #'max 0
+                                       (%get-slots-prop slots :alignment)))
+              (,union-slots (%get-slots-prop slots :slot)))
+         (notice-foreign-type-definition ',name :union ',class
+                                         ,union-size
+                                         ,union-alignment
+                                         ,union-slots)))))
+
 ;;; See also the notes regarding ABI requirements in
 ;;; NOTICE-FOREIGN-STRUCT-DEFINITION
 (defun notice-foreign-union-definition (name-and-options slots)

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -720,6 +720,10 @@ that are collected into SLOTS-VAR. Then evaluate BODY forms."
                (,slots-var (list ,@(mapcar #'first slots))))
           ,@body))))
 
+(defun %get-slots-prop (slots prop-name)
+  "Convert each slot plist from SLOTS into list of values of PROP-NAME."
+  (mapcar #'(lambda (slot) (getf slot prop-name)) slots))
+
 (defun notice-foreign-struct-definition (name options slots)
   "Parse and install a foreign structure definition."
   (destructuring-bind (&key size (class 'foreign-struct-type))

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -690,6 +690,18 @@ padding, depending on the previous slot."
             ,@body)
        (:abort (undefine-foreign-type ,name ,namespace)))))
 
+(defun notice-foreign-type-definition (name namespace class
+                                       size alignment slots)
+  "Install a foreign type NAME of namespace NAMESPACE and of class CLASS
+with relevant SIZE, ALIGNMENT, and SLOTS."
+  (check-type size (integer 0))
+  (let ((type (make-instance class :name name)))
+    (with-tentative-type-definition (name type namespace)
+      (dolist (slot slots)
+        (setf (gethash (slot-name slot) (slots type)) slot))
+      (setf (size type) size)
+      (setf (alignment type) alignment))))
+
 (defun notice-foreign-struct-definition (name options slots)
   "Parse and install a foreign structure definition."
   (destructuring-bind (&key size (class 'foreign-struct-type))

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -722,7 +722,15 @@ The foreign array must be freed with foreign-array-free."
 (define-parse-method :struct (name)
   (funcall (find-type-parser name :struct)))
 
-(defvar *defcstruct-hook* nil)
+(defvar *defcstruct-hook* nil
+  "If non-nil, *defcstruct-hook* should be a function
+of two arguments (NAME-AND-OPTIONS and SLOTS)
+that returns NIL or a list of forms
+to include in the expansion of `defcstruct'.
+NAME-AND-OPTIONS and SLOTS are equivalent to `defcstruct' arguments
+except that SLOTS doesn't contain a documentation string.
+Note: *defcstruct-hook* function must not destructively modify
+any part of its arguments.")
 
 (defmacro defcstruct (name-and-options &body fields)
   "Define the layout of a foreign structure."
@@ -743,9 +751,6 @@ The foreign array must be freed with foreign-array-free."
              (generate-struct-accessors name conc-name
                                         (mapcar #'car slots)))
          ,@(when *defcstruct-hook*
-             ;; If non-nil, *defcstruct-hook* should be a function
-             ;; of the arguments that returns NIL or a list of
-             ;; forms to include in the expansion.
              (apply *defcstruct-hook* name-and-options slots))
          (define-parse-method ,name ()
            (parse-deprecated-struct-type ',name :struct))

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -973,6 +973,19 @@ slots will be defined and stored."
 ;;; A union is a subclass of FOREIGN-STRUCT-TYPE in which all slots
 ;;; have an offset of zero.
 
+(defun union-slot-def->slot (previous-slot name type &key (count 1))
+  "Convert union slot definition to actual slot instance
+based on PREVIOUS-SLOT and slot parameters: NAME, TYPE, and COUNT."
+  (declare (ignore previous-slot))
+  (check-type count (integer 1))
+  (when (eql (canonicalize-foreign-type type) :void)
+    (simple-foreign-type-error name :union
+                               "void type isn't allowed in union slot ~S"
+                               name))
+  (list :slot (make-struct-slot name 0 type count)
+        :size (* count (foreign-type-size type))
+        :alignment (foreign-type-alignment type)))
+
 ;;; See also the notes regarding ABI requirements in
 ;;; NOTICE-FOREIGN-STRUCT-DEFINITION
 (defun notice-foreign-union-definition (name-and-options slots)

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -27,11 +27,12 @@
 
 (in-package #:cffi)
 
-(defmacro discard-docstring (body-var &optional force)
-  "Discards the first element of the list in body-var if it's a
-string and the only element (or if FORCE is T)."
-  `(when (and (stringp (car ,body-var)) (or ,force (cdr ,body-var)))
-     (pop ,body-var)))
+(defun omit-docstring (body-var)
+  "Return the original elements of BODY-VAR list but
+without the first element if the type of this element is the string."
+  (if (stringp (first body-var))
+      (rest body-var)
+      body-var))
 
 (defun single-bit-p (integer)
   "Answer whether INTEGER, which must be an integer, is a single

--- a/tests/struct.lisp
+++ b/tests/struct.lisp
@@ -703,3 +703,93 @@
   42
   (1 . 2)
   42)
+
+;; Check whether structure option :size can accept
+;; form(that is evaluated to non-negative number)
+;; instead of plain numbers.
+
+(deftest struct.size-accept-good-form
+    (let ((a 6) (b 6))
+      (defcstruct (size-accept-good-form :size (+ a b))
+        (first :int)
+        (second :int))
+      (foreign-type-size '(:struct size-accept-good-form)))
+  12)
+
+(deftest struct.size-accept-bad-form
+    (let ((a 6) (b 8))
+      (handler-case
+          (defcstruct (size-accept-bad-form :size (- a b))
+            (first :int)
+            (second :int))
+        (type-error () 'type-error)))
+  type-error)
+
+(deftest struct.size-accept-invalid-form
+    (let ((empty-list nil))
+      (handler-case
+          (defcstruct (size-accept-invalid-form :size (mapcar #'+ empty-list))
+            (first :int)
+            (second :int))
+        (type-error () 'type-error)))
+  type-error)
+
+;; Check whether structure slot option :count can accept
+;; form(that is evaluated to positive number)
+;; instead of plain numbers.
+
+(deftest struct.count-accept-good-form
+    (let ((a 8) (b 4))
+      (defcstruct count-accept-good-form
+        (first :char :count a)
+        (second :char :count b))
+      (foreign-type-size '(:struct count-accept-good-form)))
+  12)
+
+(deftest struct.count-accept-bad-form
+    (let ((a 8) (b 8))
+      (handler-case
+          (defcstruct count-accept-bad-form
+            (first :char :count a)
+            (second :char :count (- b a)))
+        (type-error () 'type-error)))
+  type-error)
+
+(deftest struct.count-accept-invalid-form
+    (let ((a "hello, world") (b 8))
+      (handler-case
+          (defcstruct count-accept-invalid-form
+            (first :char :count b)
+            (second :char :count a))
+        (type-error () 'type-error)))
+  type-error)
+
+;; Check whether structure slot option :offset can accept
+;; form(that is evaluated to non-negative number)
+;; instead of plain numbers.
+
+(deftest struct.offset-accept-good-form
+    (let ((a 8) (b 4))
+      (defcstruct offset-accept-good-form
+        (first :char :offset a)
+        (second :char :offset b))
+      (foreign-type-size '(:struct offset-accept-good-form)))
+  5)
+
+(deftest struct.offset-accept-bad-form
+    (let ((a -12) (b 8))
+      (handler-case
+          (defcstruct offset-accept-bad-form
+            (first :char :offset (+ a b))
+            (second :char :offset b))
+        (type-error () 'type-error)))
+  type-error)
+
+(deftest struct.offset-accept-invalid-form
+    (let ((a nil) (b 8))
+      (handler-case
+          (defcstruct offset-accept-invalid-form
+            (first :char :offset a)
+            (second :char :offset b))
+        (type-error () 'type-error)))
+  type-error)

--- a/tests/union.lisp
+++ b/tests/union.lisp
@@ -50,3 +50,63 @@
              t)
             (t bytes)))
   t)
+
+;; Check whether union option :size can accept
+;; form(that is evaluated to non-negative number)
+;; instead of plain numbers.
+
+(deftest union.size-accept-good-form
+    (let ((a 8) (b 8))
+      (defcunion (size-accept-good-form :size (+ a b))
+        (first :int)
+        (second :int))
+      (foreign-type-size '(:union size-accept-good-form)))
+  16)
+
+(deftest union.size-accept-bad-form
+    (let ((a 5) (b 10))
+      (handler-case
+          (defcunion (size-accept-bad-form :size (+ -25 a b))
+            (first :int)
+            (second :int))
+        (type-error () 'type-error)))
+  type-error)
+
+(deftest union.size-accept-invalid-form
+    (let ((empty-list nil))
+      (handler-case
+          (defcunion (size-accept-invalid-form :size (mapcar #'+ empty-list))
+            (first :int)
+            (second :int))
+        (type-error () 'type-error)))
+  type-error)
+
+;; Check whether union slot option :count can accept
+;; form(that is evaluated to positive number)
+;; instead of plain numbers.
+
+(deftest union.count-accept-good-form
+    (let ((a 8) (b 4))
+      (defcunion count-accept-good-form
+        (first :char :count a)
+        (second :char :count b))
+      (foreign-type-size '(:union count-accept-good-form)))
+  8)
+
+(deftest union.count-accept-bad-form
+    (let ((a 8) (b 8))
+      (handler-case
+          (defcunion count-accept-bad-form
+            (first :char :count a)
+            (second :char :count (- b a)))
+        (type-error () 'type-error)))
+  type-error)
+
+(deftest union.count-accept-invalid-form
+    (let ((a "hello, world") (b 8))
+      (handler-case
+          (defcunion count-accept-invalid-form
+            (first :char :count b)
+            (second :char :count a))
+        (type-error () 'type-error)))
+  type-error)


### PR DESCRIPTION
Hello, I've finally completed this feature. It required more job than I expected.
Changelog:
- refactor 'defcstruct' and 'defcunion' macros. So now :size, :count, and :offset options are expanded in the lexical environment of macro definition;
- add more unit tests to cover new feature;
- describe the new feature in the documentation;

The old PR - #114