### PR TITLE
Add groveller syntax to detect if preprocessor constants are defined

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -6685,6 +6685,13 @@ constant will be a symbol of the same name interned in the current
 package.
 @end deffn
 
+@deffn {Grovel Form} feature lisp-feature-name c-name &key feature-list
+
+Adds @var{lisp-feature-name} to the list @var{feature-list} if the @var{c-name}
+string is known to the C preprocessor. @var{feature-list} defaults
+to @code{cl:*features*}.
+@end deffn
+
 @deffn {Grovel Form} define name &optional value
 
 Defines an additional C preprocessor symbol, which is useful for

--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -354,6 +354,16 @@ int main(int argc, char**argv) {
   (dotimes (i (length c-names))
     (format out "~&#endif~%")))
 
+(define-grovel-syntax feature (lisp-feature-name c-name &key (feature-list 'cl:*features*))
+  (c-section-header out "feature" lisp-feature-name)
+  (format out "~&#ifdef ~A~%" c-name)
+  (c-format out "(cl:pushnew '")
+  (c-print-symbol out lisp-feature-name t)
+  (c-format out " ")
+  (c-print-symbol out feature-list)
+  (c-format out ")~%")
+  (format out "~&#endif~%"))
+
 (define-grovel-syntax cunion (union-lisp-name union-c-name &rest slots)
   (let ((documentation (when (stringp (car slots)) (pop slots))))
     (c-section-header out "cunion" union-lisp-name)

--- a/tests/grovel.lisp
+++ b/tests/grovel.lisp
@@ -31,25 +31,28 @@
     (cffi-grovel::invoke "echo" "test")
   nil nil 0)
 
+(defun grovel-forms (forms &key (quiet t))
+  (uiop:with-temporary-file (:stream grovel-stream :pathname grovel-file)
+    (with-standard-io-syntax
+      (with-open-stream (*standard-output* grovel-stream)
+        (let ((*package* (find-package :keyword)))
+          (mapc #'write forms))))
+    (let ((lisp-file (let ((*debug-io* (if quiet (make-broadcast-stream) *debug-io*)))
+                       (cffi-grovel:process-grovel-file grovel-file))))
+      (unwind-protect
+           (load lisp-file)
+        (uiop:delete-file-if-exists lisp-file)))))
+
 (defun bug-1395242-helper (enum-type base-type constant-name)
   (check-type enum-type (member constantenum cenum))
   (check-type base-type string)
   (check-type constant-name string)
   (let ((enum-name (intern (symbol-name (gensym))))
         (base-type-name (intern (symbol-name (gensym)))))
-    (uiop:with-temporary-file (:stream grovel-stream :pathname grovel-file)
-      ;; Write the grovel file
-      (with-open-stream (*standard-output* grovel-stream)
-        (write `(ctype ,base-type-name ,base-type))
-        (write `(,enum-type (,enum-name :base-type ,base-type-name)
-                            ((:value ,constant-name)))))
-      ;; Get the value of :inaddr-broadcast
-      (let ((lisp-file (cffi-grovel:process-grovel-file grovel-file)))
-        (unwind-protect
-             (progn
-               (load lisp-file)
-               (cffi:foreign-enum-value enum-name :value))
-          (uiop/filesystem:delete-file-if-exists lisp-file))))))
+    (grovel-forms `((ctype ,base-type-name ,base-type)
+                    (,enum-type (,enum-name :base-type ,base-type-name)
+                                ((:value ,constant-name)))))
+    (cffi:foreign-enum-value enum-name :value)))
 
 (deftest bug-1395242
     (labels
@@ -72,3 +75,22 @@
                ("uint32_t" ("UINT32_MAX" 4294967295) ("INT8_MIN" 4294967168))
                ("int32_t" ("INT32_MIN" -2147483648) ("INT32_MAX" 2147483647)))))
   t)
+
+(defvar *grovelled-features*)
+
+(deftest grovel-feature
+    (let ((*grovelled-features* nil))
+      (grovel-forms `((in-package :cffi-tests)
+                      (include "limits.h")
+                      (feature grovel-test-feature "CHAR_BIT")
+                      (feature :char-bit "CHAR_BIT"
+                               :feature-list *grovelled-features*)
+                      (feature :inexistent-grovel-feature
+                               "INEXISTENT_CFFI_GROVEL_FEATURE"
+                               :feature-list *grovelled-features*)))
+      (unwind-protect
+           (values (and (member 'grovel-test-feature *features*) t)
+                   (and (member :char-bit *grovelled-features*) t)
+                   (member :inexistent-grovel-feature *grovelled-features*))
+        (alexandria:removef *features* 'grovel-test-feature)))
+  t t nil)


### PR DESCRIPTION
This adds a new groveller form `feature` that detects if a preprocessor constant is defined, and adds a value to `*features*` if the constant is present. This is intended to be used when a C library defines preprocessor constants if it was compiled with certain functionality.