### PR TITLE
Push static-image-op feature into child lisp environment

### DIFF
--- a/toolchain/static-link.lisp
+++ b/toolchain/static-link.lisp
@@ -63,6 +63,7 @@
                         (setf asdf:*central-registry* ',asdf:*central-registry*)
                         (initialize-source-registry ',asdf::*source-registry-parameter*)
                         (initialize-output-translations ',asdf::*output-translations-parameter*)
+                        (pushnew :static-image-op *features*)
                         (upgrade-asdf)
                         ,@(if-let (ql-home
                                    (symbol-value (find-symbol* '*quicklisp-home* 'ql-setup nil)))


### PR DESCRIPTION
This is a fairly minor change that adds a feature flag to the child lisp process to indicate that we're in the process of building a static image.