### PR TITLE
check for ENUM-KEY instead of KEYWORD in foreign enum translators

### DIFF
--- a/src/enum.lisp
+++ b/src/enum.lisp
@@ -219,7 +219,7 @@
         (%foreign-enum-keyword type-obj value :errorp errorp))))
 
 (defmethod translate-to-foreign (value (type foreign-enum))
-  (if (keywordp value)
+  (if (typep value 'enum-key)
       (%foreign-enum-value type value :errorp t)
       value))
 
@@ -233,7 +233,7 @@
 
 (defmethod expand-to-foreign (value (type foreign-enum))
   (once-only (value)
-    `(if (keywordp ,value)
+    `(if (typep ,value 'enum-key)
          (%foreign-enum-value ,type ,value :errorp t)
          ,value)))
 


### PR DESCRIPTION
KEYWORDP can't be constant folded, since a symbol could be uninterned
after compilation, so using a more general type gets rid of some
style warnings on SBCL. %FOREIGN-ENUM-VALUE has an explicit check for
ENUM-KEY, so that is probably more correct than KEYWORD anyway.