### PR TITLE
Add functions to add and remove features during a static image op

### DIFF
--- a/examples/main-example.lisp
+++ b/examples/main-example.lisp
@@ -11,6 +11,10 @@
 (defun entry-point ()
   (when uiop:*command-line-arguments*
     (uiop:format! t "Arguments: ~A~%" (uiop:escape-command uiop:*command-line-arguments*)))
+  (when (uiop:featurep :cffi-tests-a)
+    (uiop:format! t ":CFFI-TESTS-A~%"))
+  (when (uiop:featurep :cffi-tests-b)
+    (uiop:format! t ":CFFI-TESTS-B~%"))
   (puts "hello, world!")
   (check-groveller)
   (uiop:finish-outputs)

--- a/tests/test-asdf.lisp
+++ b/tests/test-asdf.lisp
@@ -28,12 +28,19 @@
 (in-package #:cffi-tests)
 
 #.(when (cffi-toolchain::static-ops-enabled-p)
-    '(deftest test-static-program
-      (progn
-        (asdf:operate :static-program-op :cffi-tests/example)
-        (let ((program (asdf:output-file :static-program-op :cffi-tests/example)))
-          (uiop:run-program `(,(native-namestring program) "1" "2 3") :output :lines)))
-      ("Arguments: 1 \"2 3\"" "hello, world!") nil 0))
+    '(progn
+      (defmethod cffi-toolchain:static-image-new-features
+          (o (s (eql (asdf:find-system :cffi-tests/example))))
+        (list :cffi-tests-a :cffi-tests-b))
+      (defmethod cffi-toolchain:static-image-remove-features-on-dump
+          (o (s (eql (asdf:find-system :cffi-tests/example))))
+        (list :cffi-tests-b))
+      (deftest test-static-program
+       (progn
+         (asdf:operate :static-program-op :cffi-tests/example)
+         (let ((program (asdf:output-file :static-program-op :cffi-tests/example)))
+           (uiop:run-program `(,(native-namestring program) "1" "2 3") :output :lines)))
+       ("Arguments: 1 \"2 3\"" ":CFFI-TESTS-A" "hello, world!") nil 0)))
 
 (deftest test-asdf-load
     (progn

--- a/toolchain/package.lisp
+++ b/toolchain/package.lisp
@@ -40,6 +40,9 @@
    #:invoke #:invoke-build #:cc-compile
    #:link-static-library #:link-shared-library
    #:link-executable #:link-lisp-executable
+   ;; Functions from static-link
+   #:static-image-new-features
+   #:static-image-remove-features-on-dump
    ;; ASDF classes
    #:c-file #:o-file
    #:static-runtime-op #:static-image-op #:static-program-op


### PR DESCRIPTION
STATIC-IMAGE-NEW-FEATURES must return a list a features to be added in the
static runtime.

STATIC-IMAGE-REMOVE-FEATURES-ON-DUMP must return a list of features that will be
removed as part of UIOP's image dump hook.