### PR TITLE
Add MacPorts lib/ to darwin-fallback-library-path

### DIFF
--- a/src/libraries.lisp
+++ b/src/libraries.lisp
@@ -54,6 +54,7 @@
 (defun darwin-fallback-library-path ()
   (or (explode-path-environment-variable "DYLD_FALLBACK_LIBRARY_PATH")
       (list (merge-pathnames #p"lib/" (user-homedir-pathname))
+            #p"/opt/local/lib/"
             #p"/usr/local/lib/"
             #p"/usr/lib/")))
 


### PR DESCRIPTION
`darwin-fallback-library-path` doesn't support the MacPorts library path `/opt/local/lib`, causing issues like https://github.com/dimitri/pgloader/issues/161 and https://github.com/dimitri/pgloader/issues/444

This patch adds the MacPorts library path before `/usr/local/lib` and `/usr/lib`.

I successfully tested it on MacOS X 10.14.3, MacPorts 2.5.4, SBCL 1.5.0 and pgloader 3.6.4ec8613.