### PR TITLE
Make the library work with libffi.so.7

### DIFF
--- a/libffi/libffi-types.lisp
+++ b/libffi/libffi-types.lisp
@@ -71,6 +71,7 @@
 #-(or freebsd windows)
 (cenum abi
  ((:default-abi "FFI_DEFAULT_ABI"))
+ #-x86-64
  ((:sysv "FFI_SYSV"))
  ((:unix64 "FFI_UNIX64")))
 

--- a/libffi/libffi.lisp
+++ b/libffi/libffi.lisp
@@ -31,8 +31,8 @@
   (:darwin (:or "libffi.dylib" "libffi32.dylib" "/usr/lib/libffi.dylib"))
   (:solaris (:or "/usr/lib/amd64/libffi.so" "/usr/lib/libffi.so"))
   (:openbsd "libffi.so")
-  (:unix (:or "libffi.so.6" "libffi32.so.6" "libffi.so.5" "libffi32.so.5"))
-  (:windows (:or "libffi-6.dll" "libffi-5.dll" "libffi.dll"))
+  (:unix (:or "libffi.so.7" "libffi32.so.7" "libffi.so.6" "libffi32.so.6" "libffi.so.5" "libffi32.so.5"))
+  (:windows (:or "libffi-7.dll" "libffi-6.dll" "libffi-5.dll" "libffi.dll"))
   (t (:default "libffi")))
 
 (load-foreign-library 'libffi)


### PR DESCRIPTION
This makes CFFI work with libffi `3.3_rc0`+, as `ABI_SYSV` was removed there. I'm not sure if it'd continue to work with lower versions, but it should, since `ABI_UNIX64` was there all along.