### PR TITLE
cffi-toolchain: don't reintroduce bugs to ECL's ASDF

### DIFF
--- a/cffi-toolchain.asd
+++ b/cffi-toolchain.asd
@@ -40,7 +40,7 @@
     :components
     (;; This is a plain copy of bundle.lisp from ASDF 3.2.0
      ;; in case your asdf isn't up to snuff.
-     (:file "bundle" :if-feature (#.(if (version< "3.2.0" (asdf-version)) :or :and)))
+     (:file "bundle" :if-feature (#.(if (version< "3.1.8" (asdf-version)) :or :and)))
      (:file "package")
      (:file "c-toolchain" :depends-on ("package"))
      (:file "static-link" :depends-on ("bundle" "c-toolchain"))))))


### PR DESCRIPTION
ECL has a ASDF forked from version 3.1.7 version and tags it as
3.1.8 (to avoid confusion, official release following 3.1.7 is
3.2.0). This version has some bugs fixed (especially regarding
bundles) for ECL, so loading this file reintroduces said issues. Since
there is no "official" ASDF 3.1.8 release this change doesn't impact
anything except ECL.

Issue in question is regression with init names, monolithic bundles
and file causes all systems depending on it to loaded twice before
they really are compiled.