### PR TITLE
DEFWRAPPER extensions

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -862,7 +862,9 @@ were translated to C code. "
           ((:unsigned-long :ulong) "unsigned long")
           ((:long-long :llong) "long long")
           ((:unsigned-long-long :ullong) "unsigned long long")
-          (:pointer "void*")
+          (:pointer (if (cdr spec)
+                        (strcat (c-type-name (cadr spec)) "*")
+                        "void*"))
           (:string "char*")
           (t (cffi::foreign-name (car spec) nil))))))
 

--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -862,6 +862,7 @@ were translated to C code. "
           ((:unsigned-long :ulong) "unsigned long")
           ((:long-long :llong) "long long")
           ((:unsigned-long-long :ullong) "unsigned long long")
+          (:struct (strcat "struct " (cffi::foreign-name (cadr spec) nil)))
           (:pointer (if (cdr spec)
                         (strcat (c-type-name (cadr spec)) "*")
                         "void*"))

--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -174,6 +174,7 @@ int main(int argc, char**argv) {
   (%process-grovel-form (form-kind form) out (cdr form)))
 
 (defun form-kind (form)
+  "Returns a symbol from the CFFI-GROVEL package representing FORM's kind."
   ;; Using INTERN here instead of FIND-SYMBOL will result in less
   ;; cryptic error messages when an undefined grovel/wrapper form is
   ;; found.
@@ -738,6 +739,11 @@ string."
 (defvar *lisp-forms*)
 
 (defun generate-c-lib-file (input-file output-defaults)
+  "Translate the wrapper forms in INPUT-FILE to C code and write the results to
+a C file. If the file already exists, overwrite it.
+
+Returns two values: the C file's pathname, and a list of the wrapper forms that
+were translated to C code. "
   (let ((*lisp-forms* nil)
         (c-file (make-c-file-name output-defaults "__wrapper")))
     (with-open-file (out c-file :direction :output :if-exists :supersede)
@@ -845,6 +851,7 @@ string."
 ;;; FIXME: this function is not complete.  Should probably follow
 ;;; typedefs?  Should definitely understand pointer types.
 (defun c-type-name (typespec)
+  "Returns TYPESPEC's C typename as a string."
   (let ((spec (ensure-list typespec)))
     (if (stringp (car spec))
         (car spec)

--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -889,7 +889,9 @@ were translated to C code. "
       ;; output C code
       (format out "~A ~A" (c-type-name rettype) foreign-name-wrap)
       (format out "(~{~{~A ~A~}~^, ~})~%" fargs)
-      (format out "{~%  return ~A(~{~A~^, ~});~%}~%~%" foreign-name fargnames)
+      (if (eq rettype :void)
+          (format out "{~%  ~A(~{~A~^, ~});~%}~%~%" foreign-name fargnames)
+          (format out "{~%  return ~A(~{~A~^, ~});~%}~%~%" foreign-name fargnames))
       ;; matching bindings
       (push `(cffi:defcfun (,foreign-name-wrap ,lisp-name ,@options)
                  ,(cffi-type rettype)

--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -33,10 +33,14 @@
 ;;; Utils
 
 (defun parse-command-flags (flags)
+  "Takes a string of command FLAGS and returns a list of strings, each
+containing one flag. The original ordering of the flags is preserved."
   (let ((separators '(#\Space #\Tab #\Newline #\Return)))
     (remove-if 'emptyp (split-string flags :separator separators))))
 
 (defun parse-command-flags-list (strings)
+  "Takes a list of STRINGS containing command flags and returns a list of strings,
+each containing one flag. The original ordering of the flags is preserved."
   (loop for flags in strings append (parse-command-flags flags)))
 
 (defun program-argument (x)
@@ -319,6 +323,9 @@ is bound to a temporary file name, then atomically renaming that temporary file 
 ;;; Computing file names
 
 (defun make-c-file-name (output-defaults &optional suffix)
+  "Returns a pathname object with filetype \"c\", whose name and default
+component values are specified by the pathname designator OUTPUT-DEFAULTS. If
+SUFFIX is supplied, it is concatenated onto the end of the pathname's name."
   (make-pathname :type "c"
                  :name (strcat (pathname-name output-defaults) suffix)
                  :defaults output-defaults))


### PR DESCRIPTION
First time doing a pull request, feedback welcome.

This pull request makes it possible to use :void and :pointer types in DEFWRAPPER. C-TYPE-NAME can also handle struct types like (:struct timeval). Lastly, several docstrings written while exploring the wrapper and grovel functionalities are included.