### PR TITLE
Improved with-foreign-slots binding abilities to allow local names for slots

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -3761,8 +3761,9 @@ pointer.  The return value is not used.
 
 @table @var
 @item vars
-A list with each element a symbol, or list of length two with the
-first element @code{:pointer} and the second a symbol.
+A list with binding descriptors; each is either a symbol, or list with
+up to 3 elements: an optional new name to bind, an optional symbol 
+@code{:pointer} and finally the required slot symbol.
 
 @item ptr
 A foreign pointer to a structure.
@@ -3775,11 +3776,14 @@ A list of forms to be executed.
 @end table
 
 @subheading Description
-The @code{with-foreign-slots} macro creates local symbol macros for each
-var in @var{vars} to reference foreign slots in @var{ptr} of @var{type}.
-If the var is a list starting with @code{:pointer}, it will bind the
-pointer to the slot (rather than the value). It is similar to Common
-Lisp's @code{with-slots} macro.
+The @code{with-foreign-slots} macro establishes a lexical environment for
+referring to the foreign slots of @var{type} addressed by @var{ptr}.
+Like Common Lisp's @code{with-slots} macro, each var in @var{vars} may
+be a symbol naming a slot, or a list @code{(name slot)} which creates a 
+binding to a slot with a different name.
+Prefixing the slot name with @code{:pointer} creates a binding to a
+foreign pointer that addresses the slot rather than its value.  Both
+@code{(:pointer slot)} and @code{(name :pointer slot)} are acceptable.
 
 @subheading Examples
 @lisp
@@ -3801,9 +3805,9 @@ CFFI> (with-foreign-object (time :int)
               (foreign-funcall "time" :pointer (null-pointer) :int))
         (foreign-funcall "gmtime" :pointer time (:pointer (:struct tm))))
 @result{} #<A Mac Pointer #x102A30>
-CFFI> (with-foreign-slots ((sec min hour mday mon year) * (:struct tm))
+CFFI> (with-foreign-slots ((sec min hour (day-of-month mday) mon year) * (:struct tm))
         (format nil "~A:~A:~A, ~A/~A/~A"
-                hour min sec (+ 1900 year) mon mday))
+                hour min sec (+ 1900 year) mon day-of-month))
 @result{} "7:22:47, 2005/8/2"
 @end lisp
 

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -835,7 +835,7 @@ The foreign array must be freed with foreign-array-free."
       (foreign-struct-slot-set-form
        value ptr (get-slot-info (eval type) (eval slot-name)))
       form))
-
+#||
 (defmacro with-foreign-slots ((vars ptr type) &body body)
   "Create local symbol macros for each var in VARS to reference
 foreign slots in PTR of TYPE. Similar to WITH-SLOTS.
@@ -855,6 +855,30 @@ case slot-name will be bound to the pointer to that slot."
                        "Malformed slot specification ~a; must be:`name' or `(:pointer name)'"
                        var))
                   `(,var (foreign-slot-value ,ptr-var ',type ',var))))
+         ,@body))))
+||#
+(defmacro with-foreign-slots ((vars ptr type) &body body)
+  "Create local symbol macros for each var in VARS to reference
+foreign slots in PTR of TYPE. Similar to WITH-SLOTS.
+Each var can be of the form: 
+  name                       name bound to slot of same name              
+  (:pointer name)            name bound to pointer to slot of same name
+  (name slot-name)           name bound to slot-name
+  (name :pointer slot-name)  name bound to pointer to slot-name"
+
+  (let ((ptr-var (gensym "PTR")))
+    `(let ((,ptr-var ,ptr))
+       (symbol-macrolet
+           ,(loop :for var :in vars
+	       :collect
+		 (if (listp var)
+		     (let ((p1 (first var)) (p2 (second var)) (p3 (third var)))
+		       (if (eq p1 :pointer)	
+			   `(p2 (foreign-slot-pointer ,ptr-var ',type ',p2))
+			   (if (eq p2 :pointer)
+			       `(p1 (foreign-slot-pointer ,ptr-var ',type ',p3))
+			       `(p1 (foreign-slot-value ,ptr-var ',type ',p2)))))
+		     `(,var (foreign-slot-value ,ptr-var ',type ',var))))
          ,@body))))
 
 ;;; We could add an option to define a struct instead of a class, in

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -874,10 +874,10 @@ Each var can be of the form:
 		 (if (listp var)
 		     (let ((p1 (first var)) (p2 (second var)) (p3 (third var)))
 		       (if (eq p1 :pointer)	
-			   `(p2 (foreign-slot-pointer ,ptr-var ',type ',p2))
+			   `(,p2 (foreign-slot-pointer ,ptr-var ',type ',p2))
 			   (if (eq p2 :pointer)
-			       `(p1 (foreign-slot-pointer ,ptr-var ',type ',p3))
-			       `(p1 (foreign-slot-value ,ptr-var ',type ',p2)))))
+			       `(,p1 (foreign-slot-pointer ,ptr-var ',type ',p3))
+			       `(,p1 (foreign-slot-value ,ptr-var ',type ',p2)))))
 		     `(,var (foreign-slot-value ,ptr-var ',type ',var))))
          ,@body))))
 

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -835,28 +835,7 @@ The foreign array must be freed with foreign-array-free."
       (foreign-struct-slot-set-form
        value ptr (get-slot-info (eval type) (eval slot-name)))
       form))
-#||
-(defmacro with-foreign-slots ((vars ptr type) &body body)
-  "Create local symbol macros for each var in VARS to reference
-foreign slots in PTR of TYPE. Similar to WITH-SLOTS.
-Each var can be of the form: slot-name - in which case slot-name will
-be bound to the value of the slot or: (:pointer slot-name) - in which
-case slot-name will be bound to the pointer to that slot."
-  (let ((ptr-var (gensym "PTR")))
-    `(let ((,ptr-var ,ptr))
-       (symbol-macrolet
-           ,(loop :for var :in vars
-              :collect
-              (if (listp var)
-                  (if (eq (first var) :pointer)
-                      `(,(second var) (foreign-slot-pointer
-                                       ,ptr-var ',type ',(second var)))
-                      (error
-                       "Malformed slot specification ~a; must be:`name' or `(:pointer name)'"
-                       var))
-                  `(,var (foreign-slot-value ,ptr-var ',type ',var))))
-         ,@body))))
-||#
+
 (defmacro with-foreign-slots ((vars ptr type) &body body)
   "Create local symbol macros for each var in VARS to reference
 foreign slots in PTR of TYPE. Similar to WITH-SLOTS.
@@ -865,7 +844,6 @@ Each var can be of the form:
   (:pointer name)            name bound to pointer to slot of same name
   (name slot-name)           name bound to slot-name
   (name :pointer slot-name)  name bound to pointer to slot-name"
-
   (let ((ptr-var (gensym "PTR")))
     `(let ((,ptr-var ,ptr))
        (symbol-macrolet

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -848,15 +848,15 @@ Each var can be of the form:
     `(let ((,ptr-var ,ptr))
        (symbol-macrolet
            ,(loop :for var :in vars
-	       :collect
-		 (if (listp var)
-		     (let ((p1 (first var)) (p2 (second var)) (p3 (third var)))
-		       (if (eq p1 :pointer)	
-			   `(,p2 (foreign-slot-pointer ,ptr-var ',type ',p2))
-			   (if (eq p2 :pointer)
-			       `(,p1 (foreign-slot-pointer ,ptr-var ',type ',p3))
-			       `(,p1 (foreign-slot-value ,ptr-var ',type ',p2)))))
-		     `(,var (foreign-slot-value ,ptr-var ',type ',var))))
+               :collect
+                 (if (listp var)
+                     (let ((p1 (first var)) (p2 (second var)) (p3 (third var)))
+                        (if (eq p1 :pointer)	
+                           `(,p2 (foreign-slot-pointer ,ptr-var ',type ',p2))
+                           (if (eq p2 :pointer)
+                               `(,p1 (foreign-slot-pointer ,ptr-var ',type ',p3))
+                               `(,p1 (foreign-slot-value ,ptr-var ',type ',p2)))))
+                     `(,var (foreign-slot-value ,ptr-var ',type ',var))))
          ,@body))))
 
 ;;; We could add an option to define a struct instead of a class, in

--- a/tests/struct.lisp
+++ b/tests/struct.lisp
@@ -703,3 +703,30 @@
   42
   (1 . 2)
   42)
+;; Test with-foreign-slots :pointer access and new binding syntax
+(defcstruct struct.wfs
+  (tv-secs :long)
+  (tv-usecs :long))
+
+(deftest struct.with-foreign-slots.1
+    (with-foreign-object (tv 'struct.wfs)
+      (with-foreign-slots (((secs tv-secs) (usecs tv-usecs)) tv timeval)
+        (setf secs 100 usecs 200)
+        (values secs usecs)))
+  100 200)
+
+(deftest struct.with-foreign-slots.2
+    (with-foreign-object (tv 'struct.wfs)
+      (with-foreign-slots (((:pointer tv-secs) (:pointer tv-usecs)
+                            (secs tv-secs) (usecs tv-usecs))
+                           tv timeval)
+        (setf secs 100 usecs 200)
+        (values (mem-ref tv-secs :long) (mem-ref tv-usecs :long))))
+  100 200)
+
+(deftest struct.with-foreign-slots.3
+    (with-foreign-object (tv 'struct.wfs)
+      (with-foreign-slots (((psecs :pointer tv-secs) (pusecs :pointer tv-usecs) (secs tv-secs) (usecs tv-usecs)) tv timeval)
+        (setf secs 100 usecs 200)
+        (values (mem-ref psecs :long) (mem-ref pusecs :long))))
+  100 200)

--- a/tests/struct.lisp
+++ b/tests/struct.lisp
@@ -703,6 +703,7 @@
   42
   (1 . 2)
   42)
+
 ;; Test with-foreign-slots :pointer access and new binding syntax
 (defcstruct struct.wfs
   (tv-secs :long)


### PR DESCRIPTION
Now accepts with-slots-like bindings (name slotname), as well as (name :pointer slotname).  All in all a binding may be one of:
```
  name                       name bound to slot of same name              
  (:pointer name)            name bound to pointer to slot of same name
  (name slot-name)           name bound to slot-name
  (name :pointer slot-name)  name bound to pointer to slot-name
```
Rationale:   

Lispers expect binding forms to provide the ability to bind chosen names.  The inability of `with-foreign-slots`to do so is both surprising and disappointing.  It makes it awkward to use `with-foreign-slots` in functions that happen to bind symbols that happen to coincide with slot names:
```
(defun point-init (point x y)
   (with-foreign-slots ((x y) point  (:struct point))
       (setf x... ---Yikes!---
```
It is also nice to use names you like instead of slot names:
```
(with-foreign-slots (((w width)(h height)) rect (:struct rect))
  (let ((area (* w h)))
 ...
```
When using structures from another package, it is now possible to create slot accessors locally, and save a lot of package noise:
```
(with-foreign-slots (((x gtk::x)(y gtk::y)) point (:struct gtk::point))
  (+ x 11) ; x and y are now local accessors.
...
```