### PR TITLE
use FFI_COMPAT_{SYSV, LINUX64} on PPC64

### DIFF
--- a/libffi/libffi-types.lisp
+++ b/libffi/libffi-types.lisp
@@ -72,8 +72,8 @@
 (cenum abi
  ((:default-abi "FFI_DEFAULT_ABI"))
  #-x86-64
- ((:sysv "FFI_SYSV"))
- ((:unix64 "FFI_UNIX64")))
+ ((:sysv #-ppc64 "FFI_SYSV" #+ppc64 "FFI_COMPAT_SYSV"))
+ ((:unix64 #-ppc64 "FFI_UNIX64" #+ppc64 "FFI_COMPAT_LINUX64")))
 
 (ctype ffi-abi "ffi_abi")
 


### PR DESCRIPTION
This allows the groveler/libffi to be used on PPC64.

Currently I get an error:
```
; Attempting to continue anyway.
; cc -o ~/.cache/common-lisp/sbcl-1.5.8.123-e8243114d-linux-ppc64/.../quicklisp/dists/quicklisp/software/cffi_0.20.1/libffi/libffi-t
ypes__grovel-tmp5HT23M6C.o -c -g -Wall -Wundef -Wsign-compare -Wpointer-arith -O3 -m64 -fno-pie -fPIC -I~/quicklisp/dists/quicklisp/software
/cffi_0.20.1/ ~/.cache/common-lisp/sbcl-1.5.8.123-e8243114d-linux-ppc64/.../quicklisp/dists/quicklisp/software/cffi_0.20.1/libffi/li
bffi-types__grovel.c
~/.cache/common-lisp/sbcl-1.5.8.123-e8243114d-linux-ppc64/.../quicklisp/dists/quicklisp/software/cffi_0.20.1/libffi/libffi-types__gr
ovel.c: In function 'main':
~/.cache/common-lisp/sbcl-1.5.8.123-e8243114d-linux-ppc64/.../quicklisp/dists/quicklisp/software/cffi_0.20.1/libffi/libffi-types__gr
ovel.c:72:41: error: 'FFI_SYSV' undeclared (first use in this function)
   fprintf(output, "%"PRIiMAX, (intmax_t)FFI_SYSV);
                                         ^~~~~~~~
~/.cache/common-lisp/sbcl-1.5.8.123-e8243114d-linux-ppc64/.../quicklisp/dists/quicklisp/software/cffi_0.20.1/libffi/libffi-types__gr
ovel.c:72:41: note: each undeclared identifier is reported only once for each function it appears in
~/.cache/common-lisp/sbcl-1.5.8.123-e8243114d-linux-ppc64/.../quicklisp/dists/quicklisp/software/cffi_0.20.1/libffi/libffi-types__gr
ovel.c:82:41: error: 'FFI_UNIX64' undeclared (first use in this function)
   fprintf(output, "%"PRIiMAX, (intmax_t)FFI_UNIX64);
                                         ^~~~~~~~~~
~/.cache/common-lisp/sbcl-1.5.8.123-e8243114d-linux-ppc64/.../quicklisp/dists/quicklisp/software/cffi_0.20.1/libffi/libffi-types__gr
ovel.c:12:7: warning: unused variable 'autotype_tmp' [-Wunused-variable]
   int autotype_tmp;
```