### PR TITLE
Don't wait on semaphore if no :SB-THREAD feature available.

### DIFF
--- a/src/cffi-sbcl.lisp
+++ b/src/cffi-sbcl.lisp
@@ -367,8 +367,8 @@ WITH-POINTER-TO-VECTOR-DATA."
   (declare (ignore name))
   ;; As of MacOS X 10.6.6, loading things like CoreFoundation from a
   ;; thread other than the initial one results in a crash.
-  #+darwin (call-within-initial-thread 'load-shared-object path)
-  #-darwin (load-shared-object path))
+  #+(and darwin sb-thread) (call-within-initial-thread 'load-shared-object path)
+  #-(and darwin sb-thread) (load-shared-object path))
 
 ;;; SBCL 1.0.21.15 renamed SB-ALIEN::SHARED-OBJECT-FILE but introduced
 ;;; SB-ALIEN:UNLOAD-SHARED-OBJECT which we can use instead.


### PR DESCRIPTION
When we have `:darwin`, `%load-foreign-library` calls out to `call-within-initial-thread`, apparently due to some macos weirdness. `call-within-initial-thread` interrupts the main thread to load the foreign library, and then waits on a semaphore to indicate that the load was successful. If SBCL is built with `--without-sb-thread`, the above semaphore will block indefinitely since it is both not provided a timeout (unnecessary here anyway) and because SBCL has the following in its logic for `%condition-wait`:
```
  #-sb-thread
  (sb-ext:wait-for nil :timeout timeout) ; Yeah...
```

This PR extends the condition in `%load-foreign-library` to include `:sb-thread`. If we do not have `:sb-thread` then we should not be concerned about being in the initial thread since that ought to be true by definition.