### PR TITLE
Implement an enum flag that elides an error when translating an enum value that was not declared.

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -2821,7 +2821,7 @@ you should use @ref{define-foreign-type}.
 @Macro{defcenum name-and-options &body enum-list}
 
 enum-list ::= [docstring] @{ keyword | (keyword value) @}*
-name-and-options ::= name | (name &optional (base-type :int))
+name-and-options ::= name | (name &optional (base-type :int) &key allow-undeclared-values)
 
 @subheading Arguments and Values
 
@@ -2834,6 +2834,10 @@ A documentation string, ignored.
 
 @item base-type
 A symbol denoting a foreign type.
+
+@item allow-undeclared-values
+Whether to pass through integer values that were not explicitly declared
+in the enum when translating from foreign memory.
 
 @item keyword
 A keyword symbol.
@@ -2854,6 +2858,14 @@ Keywords will be automatically converted to values and vice-versa when
 being passed as arguments to or returned from foreign functions,
 respectively. The same applies to any other situations where an object
 of an @code{enum} type is expected.
+
+If a value should be translated to lisp that is not declared in the
+enum, an error will be signalled. You can elide this error and instead
+make it pass the original enum value by specifying
+@var{allow-undeclared-values}. This can be useful for very large
+enumerations of which we only care about a subset of values, or for
+enumerations that should allow for client or vendor extensions that we
+cannot know about.
 
 Types defined with @code{defcenum} canonicalize to @var{base-type}
 which is @code{:int} by default.

--- a/src/enum.lisp
+++ b/src/enum.lisp
@@ -55,7 +55,11 @@
    (value-keywords
     :initform (error "Must specify VALUE-KEYWORDS.")
     :initarg :value-keywords
-    :reader value-keywords))
+    :reader value-keywords)
+   (allow-undeclared-values
+    :initform nil
+    :initarg :allow-undeclared-values
+    :reader allow-undeclared-values))
   (:documentation "Describes a foreign enumerated type."))
 
 (deftype enum-key ()
@@ -149,7 +153,7 @@
                               bit-index->keyword :adjustable nil
                               :fill-pointer nil)))))
 
-(defun make-foreign-enum (type-name base-type values)
+(defun make-foreign-enum (type-name base-type values &key allow-undeclared-values)
   "Makes a new instance of the foreign-enum class."
   (multiple-value-bind
         (base-type keyword-values value-keywords)
@@ -158,18 +162,19 @@
                    :name type-name
                    :actual-type (parse-type base-type)
                    :keyword-values keyword-values
-                   :value-keywords value-keywords)))
+                   :value-keywords value-keywords
+                   :allow-undeclared-values allow-undeclared-values)))
 
 (defun %defcenum-like (name-and-options enum-list type-factory)
   (discard-docstring enum-list)
-  (destructuring-bind (name &optional base-type)
+  (destructuring-bind (name &optional base-type &rest args)
       (ensure-list name-and-options)
-    (let ((type (funcall type-factory name base-type enum-list)))
+    (let ((type (apply type-factory name base-type enum-list args)))
       `(eval-when (:compile-toplevel :load-toplevel :execute)
          (notice-foreign-type ',name
                               ;; ,type is not enough here, someone needs to
                               ;; define it when we're being loaded from a fasl.
-                              (,type-factory ',name ',base-type ',enum-list))
+                              (,type-factory ',name ',base-type ',enum-list ,@args))
          ,@(remove nil
                    (mapcar (lambda (key)
                              (unless (keywordp key)
@@ -229,7 +234,10 @@
         (translate-to-foreign value type)))
 
 (defmethod translate-from-foreign (value (type foreign-enum))
-  (%foreign-enum-keyword type value :errorp t))
+  (if (allow-undeclared-values type)
+      (or (%foreign-enum-keyword type value :errorp nil)
+          value)
+      (%foreign-enum-keyword type value :errorp t)))
 
 (defmethod expand-to-foreign (value (type foreign-enum))
   (once-only (value)

--- a/tests/enum.lisp
+++ b/tests/enum.lisp
@@ -130,6 +130,23 @@
   3.42
   4.42)
 
+;; Test undeclared values
+(defcenum (enum.undeclared :int :allow-undeclared-values T)
+  (:one 1)
+  (:two 2))
+
+(deftest enum.undeclared
+    (with-foreign-object (enum 'enum.undeclared 3)
+      (setf (mem-aref enum 'enum.undeclared 0) 1)
+      (setf (mem-aref enum 'enum.undeclared 1) 2)
+      (setf (mem-aref enum 'enum.undeclared 2) 3)
+      (values (mem-aref enum 'enum.undeclared 0)
+              (mem-aref enum 'enum.undeclared 1)
+              (mem-aref enum 'enum.undeclared 2)))
+  :one
+  :two
+  3)
+
 ;;;# Bitfield tests
 
 ;;; Regression test: defbitfield was misbehaving when the first value


### PR DESCRIPTION
This is useful for very large enumerations of which we're only interested in a subset, or enumerations that allow for arbitrary client or vendor extensions that we cannot be aware of. Erroring on a value that we ostensibly do not care about in such a situation is not desirable, and instead simply passing through the integer allows handling the interesting cases easily in a CASE or something similar.

If there's any style inconsistencies or other changes I should make, please let me know.