### PR TITLE
toolchain: remove non-system libaries in STATIC-IMAGE-OP

### DIFF
--- a/toolchain/package.lisp
+++ b/toolchain/package.lisp
@@ -24,7 +24,7 @@
 ;;;
 
 (uiop:define-package #:cffi-toolchain
-  (:mix #:asdf #:uiop #:common-lisp)
+  (:mix #:asdf #:uiop #:cffi #:common-lisp)
   (:import-from #:asdf/bundle
    #:link-op #:bundle-pathname-type #:bundle-type
    #:gather-operation #:gather-type)

--- a/toolchain/static-link.lisp
+++ b/toolchain/static-link.lisp
@@ -33,6 +33,16 @@
 
 ;; Problem? Its output may conflict with the program-op output :-/
 
+(defmethod perform :before ((op static-image-op) (s system))
+  ;; Close non-system foreign libraries, as grovel ones are embedded
+  ;; in the static-image. System foreign libraries still need to be
+  ;; explicitly loaded on startup, so we're keeping them loaded.
+  (register-image-dump-hook
+   (lambda ()
+     (dolist (library (list-foreign-libraries))
+       (when (eql (foreign-library-type library) :grovel-wrapper)
+	 (close-foreign-library library))))))
+
 #-(or ecl mkcl)
 (defmethod perform ((o static-image-op) (s system))
   #-(or clisp sbcl) (error "Not implemented yet")


### PR DESCRIPTION
Which applies to STATIC-PROGRAM-OP as well, because it's a
subclass. Essentially, the non-system libraries have been statically
linked (C-wise) into the image, so we don't need to have them as
foreign libraries. In fact, as foreign libraries, the restored image
will try to load them and fail, hence defeating the point.

System libraries do need to be kept, though, as they're shared
libraries, and not embedded in the image at all.

Caveat: this has only been tested on sbcl so far.