### PR TITLE
Detect statically linked libraries and avoid loading

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -6062,7 +6062,7 @@ CFFI> (let ((lib (load-foreign-library '(:framework "OpenGL"))))
 
 @Macro{define-foreign-library name-and-options @{ load-clause @}* @res{} name}
 
-name-and-options ::= name | (name &key convention search-path)
+name-and-options ::= name | (name &key canary convention search-path)
 load-clause ::= (feature library &key convention search-path)
 
 @subheading Arguments and Values
@@ -6076,6 +6076,15 @@ A feature expression.
 
 @item library
 A library designator.
+
+@item canary
+A string denoting a foreign symbol that will be searched in core
+before attempting to load the library. If that symbol is found, the
+library is assumed to be statically linked and
+@code{load-foreign-library} only marks the library as loaded.
+
+Some implementations (Clisp, ECL, SBCL) natively support static
+linking, sometimes referred to as a @emph{link kit}.
 
 @item convention
 One of @code{:cdecl} (default) or @code{:stdcall}

--- a/src/libraries.lisp
+++ b/src/libraries.lisp
@@ -135,6 +135,7 @@
    (type :initform :system :initarg :type)
    (spec :initarg :spec)
    (options :initform nil :initarg :options)
+   (load-state :initform nil :initarg :load-state :accessor foreign-library-load-state)
    (handle :initform nil :initarg :handle :accessor foreign-library-handle)
    (pathname :initform nil)))
 
@@ -188,7 +189,7 @@
         finally (return (mapcar #'pathname search-path))))
 
 (defun foreign-library-loaded-p (lib)
-  (not (null (foreign-library-handle (get-foreign-library lib)))))
+  (not (null (foreign-library-load-state (get-foreign-library lib)))))
 
 (defun list-foreign-libraries (&key (loaded-only t) type)
   "Return a list of defined foreign libraries.
@@ -230,7 +231,7 @@ all libraries are returned."
           spec))
 
 (defmethod initialize-instance :after
-    ((lib foreign-library) &key search-path
+    ((lib foreign-library) &key canary search-path
      (cconv :cdecl cconv-p)
      (calling-convention cconv calling-convention-p)
      (convention calling-convention))
@@ -250,7 +251,8 @@ all libraries are returned."
                (when value (setf (getf options key) value))))
         (set-option :convention convention)
         (set-option :search-path
-                    (mapcar #'pathname (ensure-list search-path)))))))
+                    (mapcar #'pathname (ensure-list search-path)))
+        (set-option :canary canary)))))
 
 (defun register-foreign-library (name spec &rest options)
   (let ((old-handle
@@ -374,11 +376,17 @@ This will need to be extended as we test on more OSes."
 
 (defun %do-load-foreign-library (library search-path)
   (flet ((%do-load (lib name spec)
-           (when (foreign-library-spec lib)
-             (with-slots (handle pathname) lib
-               (setf (values handle pathname)
-                     (load-foreign-library-helper
-                      name spec (foreign-library-search-path lib)))))
+           (let ((canary (getf (foreign-library-options lib) :canary)))
+             (cond
+               ((and canary (foreign-symbol-pointer canary))
+                ;; Do nothing because the library is already loaded.
+                (setf (foreign-library-load-state lib) :static))
+               ((foreign-library-spec lib)
+                (with-slots (handle pathname) lib
+                  (setf (values handle pathname)
+                        (load-foreign-library-helper
+                         name spec (foreign-library-search-path lib)))
+                  (setf (foreign-library-load-state lib) :external)))))
            lib))
     (etypecase library
       (symbol
@@ -410,7 +418,10 @@ This will need to be extended as we test on more OSes."
   "Loads a foreign LIBRARY which can be a symbol denoting a library defined
 through DEFINE-FOREIGN-LIBRARY; a pathname or string in which case we try to
 load it directly first then search for it in *FOREIGN-LIBRARY-DIRECTORIES*;
-or finally list: either (:or lib1 lib2) or (:framework <framework-name>)."
+or finally list: either (:or lib1 lib2) or (:framework <framework-name>).
+The option :CANARY can specify a symbol that will be searched to detect if
+the library is already loaded, in which case DEFINE-FOREIGN-LIBRARY will mark
+the library as loaded and return."
   (let ((library (filter-pathname library)))
     (restart-case
         (progn
@@ -446,6 +457,8 @@ or finally list: either (:or lib1 lib2) or (:framework <framework-name>)."
     (when handle
       (%close-foreign-library handle)
       (setf (foreign-library-handle lib) nil)
+      ;; Reset the load state only when the library was externally loaded.
+      (setf (foreign-library-load-state lib) nil)
       t)))
 
 (defun reload-foreign-libraries (&key (test #'foreign-library-loaded-p))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -114,6 +114,7 @@
    #:*foreign-library-directories*
    #:*darwin-framework-directories*
    #:foreign-library
+   #:foreign-library-load-state
    #:foreign-library-name
    #:foreign-library-pathname
    #:foreign-library-type


### PR DESCRIPTION
* add option :CANARY to DEFINE-FOREIGN-LIBRARY: a foreign symbol unique
to the library

If that symbol is found in the current image before
the first attempt to load the library, the latter is assumed to be
statically linked and LOAD-FOREIGN-LIBRARY only marks the load state
as :STATIC before returning.

* add new slot LOAD-STATE which, together with HANDLE, tracks the
library

| library state     | LOAD-STATE | HANDLE  |
|-------------------|------------|---------|
| not loaded        | NIL        | NIL     |
| statically linked | :STATIC    | NIL     |
| dlopen()'d        | :EXTERNAL  | non-NIL |