### PR TITLE
Do not ignore cflags of c-file.

### DIFF
--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -254,9 +254,9 @@ is bound to a temporary file name, then atomically renaming that temporary file 
   (with-temporary-output (output-file)
     (apply 'invoke `(,@builder ,output-file ,@args))))
 
-(defun cc-compile (output-file inputs)
+(defun cc-compile (output-file inputs &optional cflags)
   (apply 'invoke-builder (list *cc* "-o") output-file
-         "-c" (append *cc-flags* #-windows '("-fPIC") inputs)))
+         "-c" (append *cc-flags* cflags #-windows '("-fPIC") inputs)))
 
 (defun link-executable (output-file inputs)
   (apply 'invoke-builder (list *ld* "-o") output-file
@@ -348,7 +348,7 @@ is bound to a temporary file name, then atomically renaming that temporary file 
         ((:dll :shared-library) (link-shared-library output inputs))))))
 
 (defclass c-file (source-file)
-  ((cflags :initarg :cflags :initform :default)
+  ((cflags :initarg :cflags :initform nil)
    (type :initform "c")))
 
 (defmethod output-files ((o compile-op) (c c-file))
@@ -363,7 +363,7 @@ is bound to a temporary file name, then atomically renaming that temporary file 
 (defmethod perform ((o compile-op) (c c-file))
   (let ((i (first (input-files o c))))
     (destructuring-bind (.o .so) (output-files o c)
-      (cc-compile .o (list i))
+      (cc-compile .o (list i) (slot-value c 'cflags))
       (link-shared-library .so (list .o)))))
 
 (defmethod perform ((o load-op) (c c-file))
@@ -373,8 +373,7 @@ is bound to a temporary file name, then atomically renaming that temporary file 
 (setf (find-class 'asdf::c-file) (find-class 'c-file))
 
 (defclass o-file (source-file)
-  ((cflags :initarg :cflags :initform :default)
-   (type :initform (bundle-pathname-type :object)))
+  ((type :initform (bundle-pathname-type :object)))
   (:documentation "class for pre-compile object components"))
 
 (defmethod output-files ((op compile-op) (c o-file))


### PR DESCRIPTION
For example:

```lisp
(defsystem "foo"
  :components ((:c-file "foo" :cflags ("-lz" "-lm"))))
```

The slot is already there, but isn't actually used. It's useful when
custom compilation options need to be passed.

Additionally, the cflags slot is removed from o-file, as it does not
make sense there. Nor is it used, anyway.