### PR TITLE
Register the c-file libraries as :static.

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -121,11 +121,13 @@
    #:foreign-library-loaded-p
    #:list-foreign-libraries
    #:define-foreign-library
+   #:register-foreign-library
    #:load-foreign-library
    #:load-foreign-library-error
    #:use-foreign-library
    #:close-foreign-library
    #:reload-foreign-libraries
+   #:get-foreign-library
 
    ;; Callbacks.
    #:callback

--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -367,8 +367,10 @@ is bound to a temporary file name, then atomically renaming that temporary file 
       (link-shared-library .so (list .o)))))
 
 (defmethod perform ((o load-op) (c c-file))
-  (let ((o (second (input-files o c))))
-    (cffi:load-foreign-library (file-namestring o) :search-path (list (pathname-directory-pathname o)))))
+  (let* ((o (second (input-files o c)))
+         (f (file-namestring o)))
+    (register-foreign-library f `((t (:default ,f))))
+    (setf (foreign-library-load-state (get-foreign-library f)) :static)))
 
 (setf (find-class 'asdf::c-file) (find-class 'c-file))
 
@@ -383,8 +385,10 @@ is bound to a temporary file name, then atomically renaming that temporary file 
     (values (list o so) t)))
 
 (defmethod perform ((o load-op) (c o-file))
-  (let ((so (second (input-files o c))))
-    (cffi:load-foreign-library (file-namestring so) :search-path (list (pathname-directory-pathname so)))))
+  (let* ((so (second (input-files o c)))
+         (f (file-namestring so)))
+    (register-foreign-library f `((t (:default ,f))))
+    (setf (foreign-library-load-state (get-foreign-library f)) :static)))
 
 (setf (find-class 'asdf::o-file) (find-class 'o-file))
 


### PR DESCRIPTION
Note, however, that it is not running LOAD-FOREIGN-LIBRARY, as that
would have it reloaded when the image is restored. For example, SBCL
stores the loaded foreign libraries in its "shared objects" concept,
and tries to restore them all by default when restoring. See also
https://github.com/cffi/cffi/pull/157/ for a similar effect.

By registering the c-file libraries as :static, using the
recently-merged FOREIGN-LIBRARY-LOAD-STATE, we can make CFFI not use
dlopen() after the image is restored, when the library will be needed.