### PR TITLE
Add a test making sure :cflags of :c-file is used.

### DIFF
--- a/cffi-tests.asd
+++ b/cffi-tests.asd
@@ -86,6 +86,7 @@
      ((:file "package")
       (:cffi-wrapper-file "wrapper-example" :depends-on ("package"))
       (:cffi-grovel-file "grovel-example" :depends-on ("package"))
+      (:c-file "test" :cflags ("-DTEST=1"))
       (:file "main-example" :depends-on ("package"))))))
 
 ;;; vim: ft=lisp et

--- a/examples/main-example.lisp
+++ b/examples/main-example.lisp
@@ -4,9 +4,13 @@
   "Put a string to standard output, return non-negative length output, or EOF"
   (string :string))
 
+(defcfun "mytest" :int
+  "Returns 1.")
+
 (defun check-groveller ()
   (assert (equal (list +a0+ +a1+ +a2+ +a3+ +a4+) '(2 4 8 16 32)))
-  (assert (equal (bn 1) 32)))
+  (assert (equal (bn 1) 32))
+  (assert (equal (mytest) 1)))
 
 (defun entry-point ()
   (when uiop:*command-line-arguments*

--- a/examples/test.c
+++ b/examples/test.c
@@ -1,0 +1,4 @@
+int mytest()
+{
+	return TEST;
+}


### PR DESCRIPTION
I'm not exactly sure where those tests are run, but I've been using this to confirm it works:

```
$ sbcl --eval '(ql:quickload :cffi-grovel)' --eval '(ql:quickload :cffi-tests/example)' --eval '(asdf:operate :static-program-op :cffi-tests/example)'
$ ~/.cache/common-lisp/sbcl-2.0.4-linux-x64/[...]/cffi/cffi-tests--example 
hello, world!
```