### PR TITLE
grovel'ed shared libraries need -Wl,-soname

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -770,7 +770,10 @@ string."
                           :type :grovel-wrapper
                           :search-path ,(directory-namestring lib-file))
                        (t ,(namestring (make-so-file-name lib-soname))))
-                     (cffi:use-foreign-library ,named-library-name))
+		       (uiop/image:register-image-restore-hook
+			 (lambda () (cffi:use-foreign-library ,named-library-name)))
+		       (uiop/image:register-image-dump-hook
+			 (lambda () (cffi:close-foreign-library ,named-library-name))))
                   out)
           (fresh-line out))
         (dolist (form lisp-forms)

--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -116,7 +116,7 @@
        (setf (symbol-value sym)
              (if normalizep (normalize-flags linkset val) val))))
     (setf *ld* *cc*
-          *ld-exe-flags* `(,@*cc-flags* #-(or sunos solaris darwin) "-Wl,--export-dynamic")
+          *ld-exe-flags* `(,@*cc-flags* #-(or sunos darwin) "-Wl,--export-dynamic")
           *ld-dll-flags* (list* #+darwin "-dynamiclib" ;; -bundle ?
                                 #-darwin "-shared"
                                 *cc-flags*))))
@@ -214,7 +214,7 @@
            #+freebsd (list "-I" "/usr/local/include/")
            (split-cflags (getenv "CFLAGS")))
           *ld* *cc*
-          *ld-exe-flags* `(,@arch-flags #-(or sunos solaris darwin) "-Wl,--export-dynamic")
+          *ld-exe-flags* `(,@arch-flags #-(or sunos darwin) "-Wl,--export-dynamic")
           *ld-dll-flags* (list* #+darwin "-dynamiclib" ;; -bundle ?
                                 #-darwin "-shared"
                                 *cc-flags*)

--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -311,7 +311,10 @@ is bound to a temporary file name, then atomically renaming that temporary file 
   #-(or ecl mkcl)
   ;; Don't use a temporary file, because linking is sensitive to the output file name :-/ (or put it in a temporary directory?)
   (apply 'invoke *ld* "-o" output-file
-         (append *ld-dll-flags* inputs)))
+         (append *ld-dll-flags*
+		 #-(or windows darwin) (list (format nil "-Wl,-soname=~a"
+						     (file-namestring output-file)))
+		 inputs)))
 
 
 ;;; Computing file names

--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -116,7 +116,7 @@
        (setf (symbol-value sym)
              (if normalizep (normalize-flags linkset val) val))))
     (setf *ld* *cc*
-          *ld-exe-flags* `(,@*cc-flags* #-darwin "-Wl,--export-dynamic")
+          *ld-exe-flags* `(,@*cc-flags* #-(or sunos solaris darwin) "-Wl,--export-dynamic")
           *ld-dll-flags* (list* #+darwin "-dynamiclib" ;; -bundle ?
                                 #-darwin "-shared"
                                 *cc-flags*))))
@@ -214,7 +214,7 @@
            #+freebsd (list "-I" "/usr/local/include/")
            (split-cflags (getenv "CFLAGS")))
           *ld* *cc*
-          *ld-exe-flags* `(,@arch-flags #-darwin "-Wl,--export-dynamic")
+          *ld-exe-flags* `(,@arch-flags #-(or sunos solaris darwin) "-Wl,--export-dynamic")
           *ld-dll-flags* (list* #+darwin "-dynamiclib" ;; -bundle ?
                                 #-darwin "-shared"
                                 *cc-flags*)


### PR DESCRIPTION
So, the osicat build generates a wrapper shared library.   The typical place for this is a long path ~/.cache/common-lisp/..../quicklisp/.../libosicat.so.  When quick loaded, it dlopen()'s it directly, but without a soname embedded in the .so, Clozure ends up hard coding the full path to it in any image dumped.  End result is if you run the dumped executable, you will get an error if that same ~/.cache/common-lisp/... libosicat.so is no longer there.   With a soname, ccl instead dumps images that attempt to reload by soname rather than hardcoded absolute path.  This way, you can place the .so in a system library path or set the LD_LIBRARY_PATH environment for restored images to reload from the .so from a different place.

Even friendlier, is for the groveler to load the foreign library from a uiop image-restore-hook and close the library in an image-dump-hook.   The library closing before dumping seems to be required for ccl to correctly reload in a restored image.  (Otherwise, there is an internal condition thrown during reloading w/something running into a dead macptr). With the image restore hook re-loading a foreign library, it is preferential to the internal lisp system's reloading because cffi:*foreign-library-directories* can be consulted as well as any other dirs in the original cffi:define-foreign-library.

This may be worthwhile for more than just grovel'ed shared libraries?  It would certainly be nice if all dynamic dependencies were reloaded by cffi rather than the builtin sbcl/ccl image restorers.  Then, I wouldn't need a wrapper shell script setting a LD_LIBRARY_PATH before restoring an image.  Would closing everything via dump hooks have unintended consequences?
