### PR TITLE
Add arm64 as a platform (confirmed that this will enable at least min…

### DIFF
--- a/src/features.lisp
+++ b/src/features.lisp
@@ -66,6 +66,7 @@
    #:ppc32
    #:x86
    #:x86-64
+   #:arm64
    #:sparc
    #:sparc64
    #:hppa
@@ -100,6 +101,7 @@ that belong to the CFFI-FEATURES package."
         #+ppc ppc32
         #+x86 x86
         #+x86-64 x86-64
+	#+arm64 arm64
         #+sparc sparc
         #+sparc64 sparc64
         #+hppa hppa


### PR DESCRIPTION
…imally running cl-cffi-gtk on Debian on arm64)