### PR TITLE
Add all types defined in stdint.h

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -1848,13 +1848,16 @@ respectively.
 @ForeignType{:uint32}
 @ForeignType{:int64}
 @ForeignType{:uint64}
+@ForeignType{:size}
+@ForeignType{:ssize}
+@ForeignType{:intptr}
+@ForeignType{:uintptr}
+@ForeignType{:ptrdiff}
+@ForeignType{:offset}
 
 Foreign integer types of specific sizes, corresponding to the C types
 defined in @code{stdint.h}.
 
-@c @ForeignType{:size}
-@c @ForeignType{:ssize}
-@c @ForeignType{:ptrdiff}
 @c @ForeignType{:time}
 
 @c Foreign integer types corresponding to the standard C types (without

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -1034,24 +1034,36 @@ The buffer has dynamic extent and may be stack allocated."
 (defctype :llong  :long-long)
 (defctype :ullong :unsigned-long-long)
 
+(defmacro defctype-matching (name size-or-type base-types &key (match-by '=))
+  (let* ((target-size (typecase size-or-type
+                        (integer size-or-type)
+                        (t (foreign-type-size size-or-type))))
+         (matching-type (loop for type in base-types
+                              for size = (foreign-type-size type)
+                              when (funcall match-by target-size size)
+                              return type)))
+    (if matching-type
+        `(defctype ,name ,matching-type)
+        `(warn "Found no matching type of size ~d in~%  ~a"
+               ,target-size ',base-types))))
+
 ;;; We try to define the :[u]int{8,16,32,64} types by looking at
 ;;; the sizes of the built-in integer types and defining typedefs.
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (macrolet
-      ((match-types (sized-types mtypes)
-         `(progn
-            ,@(loop for (type . size-or-type) in sized-types
-                    for m = (car (member (if (keywordp size-or-type)
-                                             (foreign-type-size size-or-type)
-                                             size-or-type)
-                                         mtypes :key #'foreign-type-size))
-                    when m collect `(defctype ,type ,m)))))
-    ;; signed
-    (match-types ((:int8 . 1) (:int16 . 2) (:int32 . 4) (:int64 . 8)
-                  (:intptr . :pointer))
-                 (:char :short :int :long :long-long))
-    ;; unsigned
-    (match-types ((:uint8 . 1) (:uint16 . 2) (:uint32 . 4) (:uint64 . 8)
-                  (:uintptr . :pointer))
-                 (:unsigned-char :unsigned-short :unsigned-int :unsigned-long
-                  :unsigned-long-long))))
+(macrolet ((match-types (sized-types base-types)
+             `(progn ,@(loop for (name size-or-type) in sized-types
+                             collect `(defctype-matching ,name ,size-or-type ,base-types)))))
+  ;; signed
+  (match-types ((:int8 1) (:int16 2) (:int32 4) (:int64 8)
+                (:intptr :pointer))
+               (:char :short :int :long :long-long))
+  ;; unsigned
+  (match-types ((:uint8 1) (:uint16 2) (:uint32 4) (:uint64 8)
+                (:uintptr :pointer))
+               (:unsigned-char :unsigned-short :unsigned-int :unsigned-long
+                :unsigned-long-long)))
+
+;;; Pretty safe bets.
+(defctype :size #+64-bit :uint64 #+32-bit :uint32)
+(defctype :ssize #+64-bit :int64 #+32-bit :int32)
+(defctype :ptrdiff :ssize)
+(defctype :offset #+(or 64-bit bsd) :int64 #-(or 64-bit bsd) :int32)

--- a/tests/libtest.c
+++ b/tests/libtest.c
@@ -31,6 +31,7 @@
 #define DLLEXPORT
 #endif
 
+#include <sys/types.h>
 #include <stdio.h>
 #include <limits.h>
 #include <string.h>
@@ -39,11 +40,8 @@
 #include <float.h>
 #include <stdbool.h>
 #include <stdarg.h>
-
-/* MSVC doesn't have stdint.h and uses a different syntax for stdcall */
-#ifndef _MSC_VER
 #include <stdint.h>
-#endif
+#include <stddef.h>
 
 #ifdef WIN32
 #ifdef _MSC_VER
@@ -983,3 +981,37 @@ int call_stdcall_fun(int __attribute__((stdcall)) (*f)(int, int, int))
 
 /* vim: ts=4 et
 */
+
+/*
+ * STDINT.TYPES.1
+ */
+
+DLLEXPORT
+unsigned sizeof_ptrdiff(void)
+{
+  return (unsigned) sizeof(ptrdiff_t);
+}
+
+DLLEXPORT
+unsigned sizeof_size(void)
+{
+  return (unsigned) sizeof(size_t);
+}
+
+DLLEXPORT
+unsigned sizeof_offset(void)
+{
+  return (unsigned) sizeof(off_t);
+}
+
+DLLEXPORT
+unsigned sizeof_uintptr(void)
+{
+  return (unsigned) sizeof(uintptr_t);
+}
+
+DLLEXPORT
+unsigned sizeof_intptr(void)
+{
+  return (unsigned) sizeof(intptr_t);
+}

--- a/tests/misc-types.lisp
+++ b/tests/misc-types.lisp
@@ -294,3 +294,30 @@
 (deftest misc-type.expand.8
     (eval (expand-to-foreign "foo" (cffi::parse-type 'misc-type.expand.7)))
   "foo" second-value)
+
+;; stdint.h
+(defcfun "sizeof_ptrdiff" :unsigned-int)
+(defcfun "sizeof_size" :unsigned-int)
+(defcfun "sizeof_offset" :unsigned-int)
+(defcfun "sizeof_uintptr" :unsigned-int)
+(defcfun "sizeof_intptr" :unsigned-int)
+
+(deftest misc-types.sizeof.ptrdiff
+    (eql (sizeof-ptrdiff) (foreign-type-size :ptrdiff))
+  t)
+
+(deftest misc-types.sizeof.size
+    (eql (sizeof-size) (foreign-type-size :size))
+  t)
+
+(deftest misc-types.sizeof.offset
+    (eql (sizeof-offset) (foreign-type-size :offset))
+  t)
+
+(deftest misc-types.sizeof.uintptr
+    (eql (sizeof-uintptr) (foreign-type-size :uintptr))
+  t)
+
+(deftest misc-types.sizeof.intptr
+    (eql (sizeof-intptr) (foreign-type-size :intptr))
+  t)


### PR DESCRIPTION
This (finally) adds standard types defined in `stdint.h` to CFFI, meaning projects no longer manually have to define things such as `size_t`. Tests are present to compare the types that do not have explicit bittage. The tests pass on my linux AMD64 machine, though it would also need to be run on other platforms to make sure that we're doing the right thing here.

Also, CFFI will now emit a compiler or style warning if one of the precise bittage types cannot be found, and thus cannot be defined.