### PR TITLE
support arrays in structs

### DIFF
--- a/tests/union.lisp
+++ b/tests/union.lisp
@@ -37,10 +37,7 @@
   "Convert N to a list of bytes using a union."
   (with-foreign-object (obj 'uint32-bytes)
     (setf (foreign-slot-value obj 'uint32-bytes 'int-value) n)
-    (loop for i from 0 below 4
-          collect (mem-aref
-                   (foreign-slot-value obj 'uint32-bytes 'bytes)
-                   :unsigned-char i))))
+    (foreign-slot-value obj 'uint32-bytes 'bytes)))
 
 (deftest union.1
     (let ((bytes (int-to-bytes #x12345678)))


### PR DESCRIPTION
Prior to this change, foreign-struct-slot-value of an
aggregate-struct-slot would return a pointer to the beginning of the
array, and (setf foreign-struct-slot-value) would result in an error.

With this change, foreign-struct-slot-value and (setf
foreign-struct-slot-value) take the aggregate slot's count into
account.  If the count is 1, the array element's value is returned.
Otherwise, a list of the array element values is returned.

This change is not backwards compatible because
foreign-struct-slot-value of an aggregate-struct-slot no longer
returns a pointer, but a value, as can be expected from its name, from
the generic function's docstring, and from behavior of the method
specialized on simple-struct-slot.  I had to change the union.1 test
since it expected the old behavior.  I think this change also
indicates that the new behavior makes sense.