### PR TITLE
fix :string return type in cffi-libffi

### DIFF
--- a/libffi/funcall.lisp
+++ b/libffi/funcall.lisp
@@ -70,7 +70,7 @@
    types
    return-type
    (if (or (eql return-type :void)
-           (typep (parse-type return-type) 'translatable-foreign-type))
+           (typep (parse-type return-type) 'foreign-struct-type))
        call-form
        ;; built-in types won't be translated by
        ;; expand-from-foreign, we have to do it here


### PR DESCRIPTION
Prior to this change, foreign-string-to-lisp would receive a pointer
to the string pointer, and not the string pointer itself.

This issue may affect other types as well, but I did not inquire
further.