### PR TITLE
Added support for finding frameworks on Mac OS Big Sur

### DIFF
--- a/src/libraries.lisp
+++ b/src/libraries.lisp
@@ -98,13 +98,13 @@
 (defun find-darwin-framework (framework-name)
   "Searches for FRAMEWORK-NAME in *DARWIN-FRAMEWORK-DIRECTORIES*."
   (dolist (directory (parse-directories *darwin-framework-directories*))
-    (let ((path (make-pathname
-                 :name framework-name
-                 :directory
-                 (append (pathname-directory directory)
-                         (list (format nil "~A.framework" framework-name))))))
-      (when (probe-file path)
-        (return-from find-darwin-framework path)))))
+    (let ((framework-directory
+            (merge-pathnames (format nil "~A.framework/" framework-name)
+                             directory)))
+
+      (when (probe-file framework-directory)
+        (let ((path (merge-pathnames framework-name framework-directory)))
+          (return-from find-darwin-framework path))))))
 
 ;;;# Defining Foreign Libraries
 ;;;


### PR DESCRIPTION
In Mac OS Big Sur, system dynamic libraries are no longer present on the filesystem and reside in the dynamic linker cache. This change searches for the framework directory instead of the dynamic library underneath the framework directory. 

https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes

New in macOS Big Sur 11.0.1, the system ships with a built-in dynamic linker cache of all system-provided libraries. As part of this change, copies of dynamic libraries are no longer present on the filesystem. Code that attempts to check for dynamic library presence by looking for a file at a path or enumerating a directory will fail. Instead, check for library presence by attempting to dlopen() the path, which will correctly check for the library in the cache. (62986286)