### PR TITLE
sbcl/call-within-initial-thread: don't interrupt random threads.

### DIFF
--- a/src/cffi-sbcl.lisp
+++ b/src/cffi-sbcl.lisp
@@ -347,8 +347,7 @@ WITH-POINTER-TO-VECTOR-DATA."
         error
         (sem (sb-thread:make-semaphore)))
     (sb-thread:interrupt-thread
-     ;; KLUDGE: find a better way to get the initial thread.
-     (car (last (sb-thread:list-all-threads)))
+     sb-thread::*initial-thread*
      (lambda ()
        (multiple-value-setq (result error)
          (ignore-errors (apply fn args)))


### PR DESCRIPTION
Use sb-thread::*initial-thread*

For https://bugs.launchpad.net/cffi/+bug/1906993