### PR TITLE
Split *type-parsers* into three EQL hash tables

### DIFF
--- a/src/c2ffi/generator.lisp
+++ b/src/c2ffi/generator.lisp
@@ -548,7 +548,9 @@ target package."
                ;; the previous state. This avoids redefinition warning
                ;; when the generated file gets compiled and loaded
                ;; later.
-               (cffi::*type-parsers* (copy-hash-table cffi::*type-parsers*))
+               (cffi::*default-type-parsers* (copy-hash-table cffi::*default-type-parsers*))
+               (cffi::*struct-type-parsers* (copy-hash-table cffi::*struct-type-parsers*))
+               (cffi::*union-type-parsers* (copy-hash-table cffi::*union-type-parsers*))
                (*anon-name-counter* 0)
                (*anon-entities* (make-hash-table))
                (*generated-names* (mapcar (lambda (key)


### PR DESCRIPTION
Also add specialized lookup for the default table case.
This is noticeably faster in SBCL than the previous EQUAL hash table scheme.