### PR TITLE
Fix macro discard-docstring

### DIFF
--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -27,10 +27,10 @@
 
 (in-package #:cffi)
 
-(defmacro discard-docstring (body-var &optional force)
+(defmacro discard-docstring (body-var)
   "Discards the first element of the list in body-var if it's a
-string and the only element (or if FORCE is T)."
-  `(when (and (stringp (car ,body-var)) (or ,force (cdr ,body-var)))
+string."
+  `(when (stringp (car ,body-var))
      (pop ,body-var)))
 
 (defun single-bit-p (integer)


### PR DESCRIPTION
When a list has one element, `(cdr list)` is nil, so it  must be negated in `discard-docstring` for the condition to ever be true in the correct circumstances.

Without this change, calls to `defcstruct` and `defcunion` with a docstring and no slots fails with the same error:
``` common lisp
(cffi:defcstruct foo "docstring")

;; Error while parsing arguments to DESTRUCTURING-BIND:
;; invalid number of elements in
;;   "docstring"
;; to satisfy lambda list
;;   (CFFI::SLOTNAME TYPE &KEY (COUNT) CFFI::OFFSET):
;; at least 2 expected, but got a non-list
;;  [Condition of type SB-KERNEL::ARG-COUNT-ERROR]

(cffi:defcunion bar "Union docstring")

;; Error while parsing arguments to DESTRUCTURING-BIND:
;; invalid number of elements in
;;   "Union docstring"
;; to satisfy lambda list
;;   (CFFI::SLOTNAME TYPE &KEY (COUNT)):
;; at least 2 expected, but got a non-list
;;  [Condition of type SB-KERNEL::ARG-COUNT-ERROR]
```

I'm not sure how to write a test for a macro, so I didn't add one.

