### PR TITLE
on arm64 macos check /opt/homebrew/lib for libraries first

### DIFF
--- a/src/libraries.lisp
+++ b/src/libraries.lisp
@@ -54,6 +54,7 @@
 (defun darwin-fallback-library-path ()
   (or (explode-path-environment-variable "DYLD_FALLBACK_LIBRARY_PATH")
       (list (merge-pathnames #p"lib/" (user-homedir-pathname))
+            #+:arm64 #p"/opt/homebrew/lib/"
             #p"/opt/local/lib/"
             #p"/usr/local/lib/"
             #p"/usr/lib/")))

--- a/src/libraries.lisp
+++ b/src/libraries.lisp
@@ -54,7 +54,7 @@
 (defun darwin-fallback-library-path ()
   (or (explode-path-environment-variable "DYLD_FALLBACK_LIBRARY_PATH")
       (list (merge-pathnames #p"lib/" (user-homedir-pathname))
-            #+:arm64 #p"/opt/homebrew/lib/"
+            #+arm64 #p"/opt/homebrew/lib/"
             #p"/opt/local/lib/"
             #p"/usr/local/lib/"
             #p"/usr/lib/")))


### PR DESCRIPTION
 * This is the (current) default path for arm64 homebrew
   libraries. Try this before the rest.