### PR TITLE
uffi-compat: replace nil encoding with default

### DIFF
--- a/uffi-compat/uffi-compat.lisp
+++ b/uffi-compat/uffi-compat.lisp
@@ -599,9 +599,14 @@ output to *trace-output*.  Returns the shell's exit code."
   ;; NULL-TERMINATED-P in CFFI:FOREIGN-STRING-TO-LISP.
   (declare (ignore locale null-terminated-p))
   (let ((ret (gensym)))
-    `(let ((,ret (cffi:foreign-string-to-lisp ,obj
-                                              :count ,length
-                                              :encoding ,encoding)))
+    `(let ((,ret (cffi:foreign-string-to-lisp
+                  ,obj
+                  :count ,length
+                  ;; There are code paths e.g. in clsql leading here
+                  ;; with encoding being nil. UFFI replaces nil
+                  ;; encoding with default foreign encoding in those
+                  ;; cases. Copy that behavior here
+                  :encoding (or ,encoding cffi:*default-foreign-encoding*))))
        (if (equal ,ret "")
            nil
            ,ret))))


### PR DESCRIPTION
UFFI replaces encoding value `nil` with `*default-foreign-encoding*` in `convert-from-foreign-string`.

This macro may be called with nil encoding. For example if clsql-postgresql's `database-connect` fails to connect, `tidy-error-message` is called without specifying optional encoding, defaulting to nil. From there `cffi-uffi-compat:convert-from-foreign-string` is called with keyword argument `:encoding nil`. This results in an error signalled after call to `(cffi::null-terminator-len nil)`, instead of signalling the correct clsql type of error with error message from postgresql C-library.

This patch makes `cffi-uffi-compat:convert-from-foreign-string` to behave as `uffi:convert-from-foreign-string` in nil encoding case.