### PR TITLE
Fix compile error on Clozure CL.

### DIFF
--- a/src/types.lisp
+++ b/src/types.lisp
@@ -1063,7 +1063,7 @@ The buffer has dynamic extent and may be stack allocated."
                 :unsigned-long-long)))
 
 ;;; Pretty safe bets.
-(defctype :size #+64-bit :uint64 #+32-bit :uint32)
-(defctype :ssize #+64-bit :int64 #+32-bit :int32)
+(defctype :size #+(or 64-bit 64-bit-target) :uint64 #+(or 32-bit 32-bit-target) :uint32)
+(defctype :ssize #+(or 64-bit 64-bit-target) :int64 #+(or 32-bit 32-bit-target) :int32)
 (defctype :ptrdiff :ssize)
-(defctype :offset #+(or 64-bit bsd) :int64 #-(or 64-bit bsd) :int32)
+(defctype :offset #+(or 64-bit 64-bit-target bsd) :int64 #-(or 64-bit 64-bit-target bsd) :int32)


### PR DESCRIPTION
CFFI fails to build for me on Clozure CL:

```
$ ccl
Clozure Common Lisp Version 1.12  DarwinX8664

For more information about CCL, please see http://ccl.clozure.com.

CCL is free software.  It is distributed under the terms of the Apache
Licence, Version 2.0.
? (asdf:oos 'asdf:load-op 'cffi)
> Error: (:SIZE) can't be destructured against the lambda list (NAME BASE-TYPE &OPTIONAL DOCUMENTATION), because it contains 1 elements, and at least 2 are expected.
> While executing: (:INTERNAL CCL::FCOMP-MACROEXPAND-1), in process listener(1).
> Type :GO to continue, :POP to abort, :R for a list of available restarts.
> If continued: continue compilation ignoring this form
> Type :? for other options.
1 > :pop

? *features*
(CFFI-SYS::FLAT-NAMESPACE :BSD :LITTLE-ENDIAN :ASDF3.3 :ASDF3.2 :ASDF3.1 :ASDF3 :ASDF2 :ASDF :OS-MACOSX :OS-UNIX :ASDF-UNICODE :PRIMARY-CLASSES :COMMON-LISP :OPENMCL :CCL :CCL-1.2 :CCL-1.3 :CCL-1.4 :CCL-1.5 :CCL-1.6 :CCL-1.7 :CCL-1.8 :CCL-1.9 :CCL-1.10 :CCL-1.11 :CCL-1.12 :CLOZURE :CLOZURE-COMMON-LISP :ANSI-CL :UNIX :OPENMCL-UNICODE-STRINGS :IPV6 :OPENMCL-NATIVE-THREADS :OPENMCL-PARTIAL-MOP :MCL-COMMON-MOP-SUBSET :OPENMCL-MOP-2 :OPENMCL-PRIVATE-HASH-TABLES :STATIC-CONSES-SHOULD-WORK-WITH-EGC-IN-CCL :PACKAGE-LOCAL-NICKNAMES :X86-64 :X86_64 :X86-TARGET :X86-HOST :X8664-TARGET :X8664-HOST :DARWIN-HOST :DARWIN-TARGET :DARWINX86-TARGET :DARWINX8664-TARGET :DARWINX8664-HOST :64-BIT-TARGET :64-BIT-HOST :DARWIN :LITTLE-ENDIAN-TARGET :LITTLE-ENDIAN-HOST)
? 
```

Looking at types.lisp in Emacs, it became evident that neither of the feature-controls for `:size` and the similar new declarations at the bottom of the file was applicable, because the feature name is `64-bit-target` on CCL rather than just `64-bit`.