### PR TITLE
grovel: Error message for IN-PACKAGE with bad package designator

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -202,7 +202,10 @@ int main(int argc, char**argv) {
                        (flag (warn "Groveler clause FLAG is deprecated, use CC-FLAGS instead.")))
                      (case (form-kind f)
                        (in-package
-                        (setf *package* (find-package (second f)))
+                        (setf *package*
+                              (or (find-package (second f))
+                                  (error "The name ~S does not designate any package."
+                                         (second f))))
                         (push f forms))
                        (progn
                          ;; flatten progn forms


### PR DESCRIPTION
Report a bad package designator in (IN-PACKAGE :FOO) as

    The name :FOO does not designate any package.

instead of

    The value
      NIL
    is not of type
      PACKAGE