### PR TITLE
Fix (defcfun (lisp-name &rest options) ...) syntax

### DIFF
--- a/src/functions.lisp
+++ b/src/functions.lisp
@@ -359,7 +359,7 @@ arguments and does type promotion for the variadic arguments."
        (cond
          ((or (null options)
               (keywordp (first options)))
-          (values lisp-name (foreign-name spec varp) options))
+          (values lisp-name (foreign-name lisp-name varp) options))
          (t
           (assert (stringp (first options)))
           (values lisp-name (first options) (rest options))))))


### PR DESCRIPTION
Without this change, CFFI chokes on forms like `(defcfun (foo :library bar) :void)`.