### PR TITLE
Fixed for new libffi version 8

### DIFF
--- a/libffi/libffi.lisp
+++ b/libffi/libffi.lisp
@@ -31,7 +31,7 @@
   (:darwin (:or "libffi.dylib" "libffi32.dylib" "/usr/lib/libffi.dylib"))
   (:solaris (:or "/usr/lib/amd64/libffi.so" "/usr/lib/libffi.so"))
   (:openbsd "libffi.so")
-  (:unix (:or "libffi.so.7" "libffi32.so.7" "libffi.so.6" "libffi32.so.6" "libffi.so.5" "libffi32.so.5"))
+  (:unix (:or "libffi.so.8" "libffi32.so.8" "libffi.so.7" "libffi32.so.7" "libffi.so.6" "libffi32.so.6" "libffi.so.5" "libffi32.so.5"))
   (:windows (:or "libffi-7.dll" "libffi-6.dll" "libffi-5.dll" "libffi.dll"))
   (t (:default "libffi")))
 


### PR DESCRIPTION
Updating to the newest version of libffi prevents CFFI's libffi system from loading due to no longer finding the hard-coded versions of the libffi library, so this patch fixes that issue.

It might be better to solve this by just supporting both a fixed e.g. "/usr/lib/libffi.so" file as well as the list of specific versions, but this patch just adds the version 8 library paths.