### PR TITLE
Handle numbers correctly in CFFI-GROVEL::C-WRITE

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -141,7 +141,9 @@ int main(int argc, char**argv) {
         do (c-write out subform no-package))
      (c-format out ")"))
     ((symbolp form)
-     (c-print-symbol out form no-package))))
+     (c-print-symbol out form no-package))
+    ((numberp form)
+     (c-format out "~A" form))))
 
 ;;; Always NIL for now, add {ENABLE,DISABLE}-AUTO-EXPORT grovel forms
 ;;; later, if necessary.

--- a/tests/grovel-test.h
+++ b/tests/grovel-test.h
@@ -1,0 +1,15 @@
+/*
+ * Factitious C header file for testing CFFI-GROVELER
+ */
+
+#ifndef _GROVEL_TEST_H
+#define _GROVEL_TEST_H
+
+#define TAGGED_ARRAY_MAX_LENGTH 64
+
+struct tagged_array {
+  void *arr[TAGGED_ARRAY_MAX_LENGTH];
+  unsigned int len;
+};
+
+#endif // _GROVEL_TEST_H


### PR DESCRIPTION
This allows the groveler to correctly handle cstruct definitions that include arrays