### PR TITLE
Fixed ld-exe-flags for new GCC, added 'pkg-config --libs' support

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -301,6 +301,29 @@ int main(int argc, char**argv) {
                 (t
                  (grovel-error "~a" message))))))))
 
+(define-grovel-syntax ld-exe-flags (&rest flags)
+  (appendf *ld-exe-flags* (parse-command-flags-list flags)))
+
+(define-grovel-syntax pkg-config-libs (pkg &key optional)
+  (let ((output-stream (make-string-output-stream))
+        (program+args (list "pkg-config" pkg "--libs")))
+    (format *debug-io* "~&;~{ ~a~}~%" program+args)
+    (handler-case
+        (progn
+          (run-program program+args
+                       :output (make-broadcast-stream output-stream *debug-io*)
+                       :error-output output-stream)
+          (appendf *ld-exe-flags*
+                   (parse-command-flags (get-output-stream-string output-stream))))
+      (error (e)
+        (let ((message (format nil "~a~&~%~a~&"
+                               e (get-output-stream-string output-stream))))
+          (cond (optional
+                 (format *debug-io* "~&; ERROR: ~a" message)
+                 (format *debug-io* "~&~%; Attempting to continue anyway.~%"))
+                (t
+                 (grovel-error "~a" message))))))))
+
 ;;; This form also has some "read time" effects. See GENERATE-C-FILE.
 (define-grovel-syntax in-package (name)
   (c-format out "(cl:in-package #:~A)~%~%" name))

--- a/toolchain/c-toolchain.lisp
+++ b/toolchain/c-toolchain.lisp
@@ -260,7 +260,7 @@ is bound to a temporary file name, then atomically renaming that temporary file 
 
 (defun link-executable (output-file inputs)
   (apply 'invoke-builder (list *ld* "-o") output-file
-         (append *ld-exe-flags* inputs)))
+         (append inputs *ld-exe-flags*)))
 
 (defun link-lisp-executable (output-file inputs)
   #+ecl


### PR DESCRIPTION
After updating GCC (11.1.0) and HDF5 (1.12.1), the groveler no longer called the linker with arguments in the right order (--as-needed means elements from libraries that come before object files in the command string will be excluded, leading to "undefined reference to..." errors), and additionally there was a need to add linker flags for generating groveler executables, so I changed the following:

- Placed ld-exe-flags at the end of the link-executable command to ensure libraries come after objects
- Added new syntax pkg-config-libs with similar usage as pkg-config-cflags but for "pkg-config X --libs"
- Added new syntax ld-exe-flags with similar usage as cc-flags to explicitly add library flags

This should work for old and new GCC since as far as I'm aware it's a problem with newer GCC being more picky with the --as-needed flag, but I don't currently have an older GCC installed to explicitly test it.