### PR TITLE
store pointer to a foreign-alloc so expanded code can modify pointer

### DIFF
--- a/src/cffi-sbcl.lisp
+++ b/src/cffi-sbcl.lisp
@@ -155,11 +155,13 @@ SIZE-VAR is supplied, it will be bound to SIZE during BODY."
                  (,var (alien-sap ,alien-var)))
              (declare (ignorable ,size-var))
              ,@body)))
-      `(let* ((,size-var ,size)
-              (,var (%foreign-alloc ,size-var)))
-         (unwind-protect
-              (progn ,@body)
-           (foreign-free ,var)))))
+      (let ((free-ptr (gensym "FREE-PTR")))
+        `(let* ((,size-var ,size)
+                (,var (%foreign-alloc ,size-var))
+                (,free-ptr ,var))
+           (unwind-protect
+                (progn ,@body)
+             (foreign-free ,free-ptr))))))
 
 ;;;# Shareable Vectors
 ;;;


### PR DESCRIPTION
Without this it is possible that expanded code in `,@body` will perform pointer maths (e.g. `cffi:incf-pointer`) which causes a segv when freeing the original pointer, since it may no longer reference valid memory.