### PR TITLE
Import latest local-cpu and *target-archs* from cl-autowrap

### DIFF
--- a/src/c2ffi/c2ffi.lisp
+++ b/src/c2ffi/c2ffi.lisp
@@ -37,7 +37,8 @@
   #+x86-64 "x86_64"
   #+(and (not (or x86-64 freebsd)) x86) "i686"
   #+(and (not x86-64) x86 freebsd) "i386"
-  #+arm "arm")
+  #+arm "arm"
+  #+arm64 "aarch64")
 
 (defun local-vendor ()
   #+(or linux windows) "-pc"
@@ -45,14 +46,17 @@
   #+(not (or linux windows darwin)) "-unknown")
 
 (defun local-os ()
-  #+linux "-linux"
+  #+(or linux android) "-linux"
   #+windows "-windows-msvc"
   #+darwin "-darwin9"
-  #+freebsd "-freebsd")
+  #+freebsd "-freebsd"
+  #+openbsd "-openbsd")
 
 (defun local-environment ()
   #+linux "-gnu"
-  #-linux "")
+  #+(and arm android) "-androideabi"
+  #+(and (not arm) android) "-android"
+  #+(not (or linux android)) "")
 
 (defun local-arch ()
   (strcat (local-cpu) (local-vendor) (local-os) (local-environment)))
@@ -65,7 +69,16 @@
     "i686-apple-darwin9"
     "x86_64-apple-darwin9"
     "i386-unknown-freebsd"
-    "x86_64-unknown-freebsd"))
+    "x86_64-unknown-freebsd"
+    "i386-unknown-openbsd"
+    "x86_64-unknown-openbsd"
+    "arm-pc-linux-gnu"
+    "aarch64-pc-linux-gnu"
+    "aarch64-apple-darwin9"
+    "arm-unknown-linux-androideabi"
+    "aarch64-unknown-linux-android"
+    "i686-unknown-linux-android"
+    "x86_64-unknown-linux-android"))
 
 (defvar *c2ffi-executable* "c2ffi")
 (defvar *c2ffi-extra-arguments* (list))


### PR DESCRIPTION
Added the `#+arm64` branch to `local-cpu`, to be able to generate the `.spec` file for `aarch64-apple-darwin9`.

Although not necessary for this fix, other updates in `cl-autowrap` were included; I can remove them if needed.

The following example now correctly generates the `.spec` file for `aarch64-apple-darwin9` when `c2ffi` is available in the path:

```lisp
(defsystem "cimgui-cffi"
  :version "0.1.0"
  :author ""
  :license ""
  :defsystem-depends-on (:cffi/c2ffi)
  :depends-on ("cffi"
               "cffi/c2ffi"
               "cffi-libffi"
               "cl-change-case"
               "str")
  :pathname "cimgui-cffi"
  :serial t
  :components
  ((:file "package")
   (:file "prelude")
   (:module "spec"
            :components
            ((:cffi/c2ffi-file
              "cimgui.h"
              :package #:cimgui.lib
              :foreign-library-name "cimgui"
              :ffi-name-transformer "cimgui-cffi.prelude::ffi-name-transformer"
              :include-sources ()
              :foreign-library-spec ((t (:default "libcimgui"))))))))
```