### PR TITLE
Add additional DLL names to libffi Windows spec

### DIFF
--- a/libffi/libffi.lisp
+++ b/libffi/libffi.lisp
@@ -32,7 +32,8 @@
   (:solaris (:or "/usr/lib/amd64/libffi.so" "/usr/lib/libffi.so"))
   ((:or :netbsd :freebsd :openbsd) "libffi.so")
   (:unix (:or "libffi.so.8" "libffi32.so.8" "libffi.so.7" "libffi32.so.7" "libffi.so.6" "libffi32.so.6" "libffi.so.5" "libffi32.so.5" "libffi.so" "libffi32.so"))
-  (:windows (:or "libffi-8.dll" "libffi-7.dll" "libffi-6.dll" "libffi-5.dll" "libffi.dll"))
+  (:windows (:or "libffi-8.dll" "libffi-7.dll" "libffi-6.dll" "libffi-5.dll" "libffi.dll"
+                 "ffi-8.dll" "ffi-7.dll" "ffi-6.dll" "ffi-5.dll" "ffi.dll"))
   (t (:default "libffi")))
 
 (load-foreign-library 'libffi)


### PR DESCRIPTION
I want to use cffi in a Conda environment on Windows, but the Conda-distributed package for libffi drops the `lib` prefix when installing the DLL:

```
>>> Library/bin/ffi-8.dll <<<
Library/include/ffi.h
Library/include/ffitarget.h
Library/lib/ffi.lib
Library/lib/libffi.lib
Library/lib/pkgconfig/libffi.pc
Library/share/info/libffi.info
Library/share/man/man3/ffi.3
Library/share/man/man3/ffi_call.3
Library/share/man/man3/ffi_prep_cif.3
Library/share/man/man3/ffi_prep_cif_var.3
```

This PR makes it so that cffi can find these DLLs.