### PR TITLE
(maybe temporary) workaround for defcfun.undefined test on CMUCL

### DIFF
--- a/src/functions.lisp
+++ b/src/functions.lisp
@@ -235,6 +235,7 @@ arguments and does type promotion for the variadic arguments."
       `(progn
          ,prelude
          (defun ,lisp-name ,arg-names
+           #+cmucl (declare (notinline alien::%heap-alien))
            ,@(ensure-list docstring)
            ,(if call-by-value
                 `(foreign-funcall

--- a/tests/defcfun.lisp
+++ b/tests/defcfun.lisp
@@ -469,7 +469,7 @@
 ;;; regression test: defining an undefined foreign function should only
 ;;; throw some sort of warning, not signal an error.
 
-#+(or cmucl (and sbcl win32))
+#+(and sbcl win32)
 (pushnew 'defcfun.undefined rtest::*expected-failures*)
 
 (deftest defcfun.undefined


### PR DESCRIPTION
There was a discussion here: https://gitlab.common-lisp.net/cmucl/cmucl/-/issues/74.

This workaround allows to define foreign functions with `defcfun` without loading the corresponding foreign library first on CMUCL.