### PR TITLE
FIX: Use LD_LIBRARY_PATH ENV variable

### DIFF
--- a/src/libraries.lisp
+++ b/src/libraries.lisp
@@ -60,7 +60,7 @@
             #p"/usr/lib/")))
 
 (defvar *foreign-library-directories*
-  (if (featurep :darwin)
+  (if (or (featurep :darwin) (featurep :unix))
       '((explode-path-environment-variable "LD_LIBRARY_PATH")
         (explode-path-environment-variable "DYLD_LIBRARY_PATH")
         (uiop:getcwd)


### PR DESCRIPTION
This PR fixes the issue #378 on Linux not reading LD_LIBRARY_PATH as it does in Darwin.

