### PR TITLE
cffi-manual.texinfo and cffi-sys-spec.texinfo for size_t

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -1391,9 +1391,10 @@ size_t
 @var{function}(void *ptr, size_t size, size_t nmemb, void *stream);
 @end example
 
-@impnote{size_t is almost always an unsigned int.  You can get this
-and many other types using feature tests for your system by using
-cffi-grovel.}
+@impnote{@code{size_t} is almost always an unsigned int with the same number
+of bits as a pointer.  It is provided in @cffi{} as @code{:size}.
+You can also get this and many other types using feature tests for
+your system by using cffi-grovel.}
 
 The above signature trivially translates into a @cffi{}
 @code{defcallback} form, as follows.
@@ -1857,6 +1858,13 @@ respectively.
 
 Foreign integer types of specific sizes, corresponding to the C types
 defined in @code{stdint.h}.
+
+
+@code{:size}, @code{:ssize},
+@code{:intptr}, @code{:uintptr}, @code{:ptrdiff}, and @code{:offset}
+correspond to C types  @code{size_t}, @code{ssize_t},
+@code{intptr_t}, @code{uintptr_t}, @code{ptrdiff_t}, and @code{offset_t}.
+
 
 @c @ForeignType{:time}
 

--- a/doc/cffi-sys-spec.texinfo
+++ b/doc/cffi-sys-spec.texinfo
@@ -140,8 +140,9 @@ defined in @code{stdint.h}.
 @deftpx {Foreign Type} :ssize
 @deftpx {Foreign Type} :ptrdiff
 @deftpx {Foreign Type} :time
-Foreign integer types corresponding to the standard C types (without
-the @code{_t} suffix).
+Foreign integer types corresponding to the standard C types.   They correspond to C types
+@code{size_t}, @code{ssize_t}, @code{ptrdiff_t}, and @code{time_t}, respectively.
+
 @end deftp
 
 @impnote{I'm sure there are more of these that could be useful, let's


### PR DESCRIPTION
modified cffi-manual.texinfo to remove claim that size_t is an unsigned int (it's usually a pointer-size int); added reference to size_t in other cffi-sys-spec.texinfo