### PR TITLE
Add support for ECL long double

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -1882,7 +1882,7 @@ precision, among each respective category.
 
 @ForeignType{:long-double}
 
-This type is only supported on SCL.
+This type is only supported on ECL and SCL.
 
 @ForeignType{:pointer &optional type}
 

--- a/src/cffi-ecl.lisp
+++ b/src/cffi-ecl.lisp
@@ -159,6 +159,8 @@ WITH-POINTER-TO-VECTOR-DATA."
     (:unsigned-long-long :unsigned-long-long "unsigned long long")
     (:float           :float           "float")
     (:double          :double          "double")
+    #+long-float
+    (:long-double     :long-double     "long double")
     (:pointer         :pointer-void    "void*")
     (:void            :void            "void")))
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -124,7 +124,7 @@
    #:no-stdcall
    #:flat-namespace
 
-   ;; Only SCL supports long-double...
+   ;; Only ECL and SCL support long-double...
    ;;#:no-long-double
 
    ;; Features related to the operating system.

--- a/src/types.lisp
+++ b/src/types.lisp
@@ -102,7 +102,7 @@
 
 ;;; When some lisp other than SCL supports :long-double we should
 ;;; use #-cffi-sys::no-long-double here instead.
-#+(and scl long-float) (define-built-in-foreign-type :long-double)
+#+(and (or ecl scl) long-float) (define-built-in-foreign-type :long-double)
 
 (defparameter *possible-float-types* '(:float :double :long-double))
 

--- a/tests/defcfun.lisp
+++ b/tests/defcfun.lisp
@@ -199,11 +199,11 @@
   6.0d0)
 
 
-#+(and scl long-float)
+#+(and (or ecl scl) long-float)
 (defcfun ("sqrtl" c-sqrtl) :long-double
   (n :long-double))
 
-#+(and scl long-float)
+#+(and (or ecl scl) long-float)
 (deftest defcfun.long-double
     (c-sqrtl 36.0l0)
   6.0l0)
@@ -322,7 +322,7 @@
       (sprintf s "%.0f" :double (* pi 100d0)))
   "314")
 
-#+(and scl long-float)
+#+(and (or ecl scl) long-float)
 (deftest defcfun.varargs.long-double
     (with-foreign-pointer-as-string (s 100)
       (setf (mem-ref s :char) 0)

--- a/tests/memory.lisp
+++ b/tests/memory.lisp
@@ -129,7 +129,7 @@
 ;;; TODO: use something like *DOUBLE-MIN/MAX* above once we actually
 ;;; have an available lisp that supports long double.
 ;#-cffi-sys::no-long-float
-#+(and scl long-double)
+#+(and (or ecl scl) long-float)
 (progn
   (deftest deref.long-double.1
       (with-foreign-object (p :long-double)


### PR DESCRIPTION
Also fix feature expression for SCL that used long-double instead of long-float.