### PR TITLE
Initial fix for Allegro CL 11

### DIFF
--- a/src/cffi-allegro.lisp
+++ b/src/cffi-allegro.lisp
@@ -257,7 +257,8 @@ WITH-POINTER-TO-VECTOR-DATA."
   (declare (ignore convention library))
   (multiple-value-bind (types fargs rettype)
       (foreign-funcall-type-and-args args)
-    `(system::ff-funcall
+    `(#+(version>= 11 0) system::ff_funcall
+      #-(version>= 11 0) system::ff-funcall
       (load-time-value (excl::determine-foreign-address
                         '(,name :language :c)
                         #-(version>= 8 1) ff::ep-flag-never-release
@@ -297,7 +298,8 @@ WITH-POINTER-TO-VECTOR-DATA."
     (with-unique-names (entry-vec)
       `(let ((,entry-vec (excl::make-entry-vec-boa)))
          (setf (aref ,entry-vec 1) ,ptr) ; set jump address
-         (system::ff-funcall
+         (#+(version>= 11 0) system::ff_funcall
+          #-(version>= 11 0) system::ff-funcall
           ,entry-vec
           ;; arg types {'(:c-type lisp-type) argN}*
           ,@(mapcan (lambda (type arg)


### PR DESCRIPTION
The internal system::ff_funcall function was renamed to system::ff_funcall. This gets us most of the way there, but there are still issues with vararg functions.

There are still some outstanding issues ([tests that fail in 11 but not in 10](https://github.com/cffi/cffi/issues/381#issuecomment-2181397061)), but this seems better than nothing for now.