### PR TITLE
grovel: don't treat pkg-config stderr as compilation flags

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -289,7 +289,7 @@ int main(int argc, char**argv) {
         (progn
           (run-program program+args
                        :output (make-broadcast-stream output-stream *debug-io*)
-                       :error-output output-stream)
+                       :error-output *debug-io*)
           (appendf *cc-flags*
                    (parse-command-flags (get-output-stream-string output-stream))))
       (error (e)


### PR DESCRIPTION
Hey. I'm being bitten by the fact that grovel subsystem interprets `pkg-config` stderr as the compilation flags for GCC, while its stderr usually contains some kind of warnings. 

This small PR fixes the problem by redirecting stderr of `pkg-config` called by groveller to `*debug-io*`.
