### PR TITLE
fix for cmucl: close the correct library

### DIFF
--- a/src/cffi-cmucl.lisp
+++ b/src/cffi-cmucl.lisp
@@ -318,14 +318,14 @@ WITH-POINTER-TO-VECTOR-DATA."
       ((null ret) (cdr (rassoc path sys::*global-table* :test #'string=)))
       ;; The library has been loaded, but since SYS::LOAD-OBJECT-FILE
       ;; returns an alist of *all* loaded libraries along with their addresses
-      ;; we return only the handler associated with the library just loaded.
+      ;; we return only the handle associated with the library just loaded.
       (t (cdr (rassoc path ret :test #'string=))))))
 
 ;;; XXX: doesn't work on Darwin; does not check for errors. I suppose we'd
 ;;; want something like SBCL's dlclose-or-lose in foreign-load.lisp:66
-(defun %close-foreign-library (handler)
+(defun %close-foreign-library (handle)
   "Closes a foreign library."
-  (let ((lib (rassoc (ext:unix-namestring handler) sys::*global-table*
+  (let ((lib (rassoc handle sys::*global-table*
                      :test #'string=)))
     (sys::dlclose (car lib))
     (setf (car lib) (sys:int-sap 0))))


### PR DESCRIPTION
cffi's library handle is set to whatever %load-foreign-library returns. That same handle is passed to %close-foreign-library.

%load-foreign-library returns an index into cmucl's *global-table*. %close-foreign-library wants to index into the *global-table*, for which it can and should use the handle directly rather than trying to change it via unix-namestring.

In particular, for a library loaded from /lib or the LD_LIBRARY_PATH (rather than in the current directory or cffi:*foreign-library-directories*), the handle (i.e. index into *global-table*) is _not_ a relative or absolute pathname and thus applying unix-namestring to it produces NIL. That prevents the correct *global-table* entry from being closed.