### PR TITLE
Look up CallbackReference class robustly

### DIFF
--- a/src/cffi-abcl.lisp
+++ b/src/cffi-abcl.lisp
@@ -669,7 +669,7 @@ interface extends specified as fully qualifed dotted Java names."
       (write-byte (jarray-ref class-bytes i) stream))))
 
 (defun %callback (name)
-  (or (#"getFunctionPointer" 'com.sun.jna.CallbackReference
+  (or (#"getFunctionPointer" '|com.sun.jna.CallbackReference|
                              (gethash name *callbacks*))
       (error "Undefined callback: ~S" name)))
 


### PR DESCRIPTION
JSS has a table of class names that it builds by scanning jar files on the classpath but not directories. (Maybe that's on purpose in case the user has on the classpath a large directory intended to be probed for class files but not recursively scanned.)

So rather than rely on such heuristics from JSS, it's more robust to pass JSS the full correct case-sensitive class name. That lets cffi work even when the JNA library is provided as a directory of class files instead of a jar file. Otherwise cffi only works when JNA is provided as a jar file.