### PR TITLE
cmucl vararg fix

### DIFF
--- a/src/cffi-cmucl.lisp
+++ b/src/cffi-cmucl.lisp
@@ -230,7 +230,7 @@ WITH-POINTER-TO-VECTOR-DATA."
 
 (defmacro %%foreign-funcall (name types fargs rettype)
   "Internal guts of %FOREIGN-FUNCALL."
-  `(let ()
+  `(locally
      ; https://gitlab.common-lisp.net/cmucl/cmucl/-/issues/74
      (declare (notinline alien::%heap-alien))
      (alien-funcall

--- a/src/cffi-cmucl.lisp
+++ b/src/cffi-cmucl.lisp
@@ -230,9 +230,12 @@ WITH-POINTER-TO-VECTOR-DATA."
 
 (defmacro %%foreign-funcall (name types fargs rettype)
   "Internal guts of %FOREIGN-FUNCALL."
-  `(alien-funcall
-    (extern-alien ,name (function ,rettype ,@types))
-    ,@fargs))
+  `(let ()
+     ; https://gitlab.common-lisp.net/cmucl/cmucl/-/issues/74
+     (declare (notinline alien::%heap-alien))
+     (alien-funcall
+      (extern-alien ,name (function ,rettype ,@types))
+      ,@fargs)))
 
 (defmacro %foreign-funcall (name args &key library convention)
   "Perform a foreign function call, document it more later."

--- a/src/functions.lisp
+++ b/src/functions.lisp
@@ -235,7 +235,6 @@ arguments and does type promotion for the variadic arguments."
       `(progn
          ,prelude
          (defun ,lisp-name ,arg-names
-           #+cmucl (declare (notinline alien::%heap-alien))
            ,@(ensure-list docstring)
            ,(if call-by-value
                 `(foreign-funcall

--- a/tests/defcfun.lisp
+++ b/tests/defcfun.lisp
@@ -479,6 +479,14 @@
       t)
   t)
 
+(deftest defcfun.undefined-vararg
+  (progn
+    (eval '(defcfun ("undef-vararg" undef-vararg) :void &rest))
+    (eval '(defun undef-vararg-caller () (undef-vararg)))
+    (compile 'undef-vararg-caller)
+    t)
+  t)
+
 ;;; Test whether all doubles are passed correctly. On some platforms, eg.
 ;;; darwin/ppc, some are passed on registers others on the stack.
 (defcfun "sum_double26" :double


### PR DESCRIPTION
https://gitlab.common-lisp.net/cmucl/cmucl/-/issues/74
led to this fix
https://github.com/cffi/cffi/pull/361
revision: c42b42e93a784c9396047078eff9caed257d7c28
but the fix was only partial.

This patch completes that fix.

Elaboration:

(defcfun ...)
expands into a defun if given fixed args or a defmacro if given varargs.
The original fix addressed the fixed-arg case but not the vararg case.

For the vararg case where defcfun expands into a defmacro, it's the
callers of that macro that need protecting with notinline, but they
don't get that protection.

One solution is to chase down the code for that other case and
add a notinline declaration to it. That leads to early-types.lisp's
expand-to-foreign-dyn :around method's changing from
`(unwind-protect (progn ,@body))`
to
```
(unwind-protect
  ((lambda ()
     #+cmucl (declare (notinline alien::%heap-alien))
     ,@body)))
```
but I don't know if there are other possible places that should also be
modified to have a notinline declaration.

A better solution regardless is move the existing notinline declaration
deeper to a single place from which both cases get protected. That's
what this patch does.

The following snippet fails without this patch and passes with it.
```
(cffi:defcfun ("H1" h2) :void &rest)
(defun h () (h2))
(compile 'h)
```