### PR TITLE
Enable defcfun.undefined test for sbcl on win32

### DIFF
--- a/tests/defcfun.lisp
+++ b/tests/defcfun.lisp
@@ -469,9 +469,6 @@
 ;;; regression test: defining an undefined foreign function should only
 ;;; throw some sort of warning, not signal an error.
 
-#+(and sbcl win32)
-(pushnew 'defcfun.undefined rtest::*expected-failures*)
-
 (deftest defcfun.undefined
     (progn
       (eval '(defcfun ("undefined_foreign_function" undefined-foreign-function) :void))


### PR DESCRIPTION
It was treated as an expected failure on that platform, presumably because it failed historically. I tried the body of the test on sbcl-2.4.3 (x86-64) in Wine (i.e. sbcl, win32) and found no problems. It ran fine.