### PR TITLE
Make tests loadable on clisp without threads

### DIFF
--- a/cffi-tests.asd
+++ b/cffi-tests.asd
@@ -53,8 +53,8 @@
 (defsystem "cffi-tests"
   :description "Unit tests for CFFI."
   :depends-on ("uiop" "cffi-grovel" "cffi-libffi"
-               #-(and clisp (not :mt)) "bordeaux-threads"
-               #-ecl "rt" #+ecl (:require "rt"))
+               (:feature (:or (:not :clisp) :mt) "bordeaux-threads")
+               (:feature (:not :ecl) "rt") (:feature :ecl (:require "rt")))
   :components
   ((:module "tests"
     :components

--- a/cffi-tests.asd
+++ b/cffi-tests.asd
@@ -52,7 +52,9 @@
 
 (defsystem "cffi-tests"
   :description "Unit tests for CFFI."
-  :depends-on ("uiop" "cffi-grovel" "cffi-libffi" "bordeaux-threads" #-ecl "rt" #+ecl (:require "rt"))
+  :depends-on ("uiop" "cffi-grovel" "cffi-libffi"
+               #-(and clisp (not :mt)) "bordeaux-threads"
+               #-ecl "rt" #+ecl (:require "rt"))
   :components
   ((:module "tests"
     :components

--- a/tests/bindings.lisp
+++ b/tests/bindings.lisp
@@ -63,6 +63,7 @@
                         ,result)))
       result)))
 
+#+bordeaux-threads
 (defun call-within-new-thread (fn &rest args)
   (let (result
         error


### PR DESCRIPTION
Bordeaux-threads is by design no longer loadable on clisp lacking thread support. (And clisp's default build everywhere omits thread support because its threading implementation is known to be incomplete and use data structures that aren't thread safe.)