### PR TITLE
grovel wrapper syntax: `flags`, `cc-flags`, `ld-flags`.

### DIFF
--- a/grovel/grovel.lisp
+++ b/grovel/grovel.lisp
@@ -832,6 +832,15 @@ string."
   (dolist (string strings)
     (write-line string out)))
 
+(define-wrapper-syntax flags (&rest flags)
+  (appendf *cc-flags* (parse-command-flags-list flags)))
+
+(define-wrapper-syntax cc-flags (&rest flags)
+  (appendf *cc-flags* (parse-command-flags-list flags)))
+
+(define-wrapper-syntax ld-flags (&rest flags)
+  (appendf *ld-dll-flags* (parse-command-flags-list flags)))
+
 (define-wrapper-syntax flag (&rest flags)
   (appendf *cc-flags* (parse-command-flags-list flags)))
 


### PR DESCRIPTION
The CFFI documentation:
13.5 Wrapper for Inline/Static Functions and Macros https://cffi.common-lisp.dev/manual/html_node/Wrapper-for-Inline_002fStatic-Functions-and-Macros.html

defines:
+ (flags &rest flags): but the wrapper syntax is missing (only exists `flag', inconsists with documentation)

proprosal:
+ (cc-flags &rest flags): so this should be same as grovel file
+ (ld-flags &rest flags): so this should custom ld process behavior

test:

(cc-flags "-ObjC" "-framework" "Foundation")
(ld-flags "-framework" "Foundation")

(c "

typedef void (*coca_lisp_callback_t)(id);

static coca_lisp_callback_t coca_lisp_exception_callback = NULL;

void coca_lisp_call_wrapper (void (*call)(void)) {
  @try {
    call();
  }
  @catch (NSException *e) {
    if (coca_lisp_exception_callback) {
      coca_lisp_exception_callback(e);
    }
  }
}
")

this is used in
https://github.com/li-yiyang/coca/commit/8e3c52b3b79ea069103c3734b279711d085c01f6