### PR TITLE
clasp: map CFFI's :default library to RTLD_DEFAULT

### DIFF
--- a/src/cffi-clasp.lisp
+++ b/src/cffi-clasp.lisp
@@ -152,7 +152,8 @@ WITH-POINTER-TO-VECTOR-DATA."
 
 (defun %foreign-symbol-pointer (name library)
   "Returns a pointer to a foreign symbol NAME."
-  (clasp-ffi:%foreign-symbol-pointer name library))
+  ;; CFFI's :default library marker means the global namespace (RTLD_DEFAULT).
+  (clasp-ffi:%foreign-symbol-pointer name (if (eq library :default) :rtld-default library)))
 
 (defun native-namestring (pathname)
   (namestring pathname))


### PR DESCRIPTION
On Clasp, `cffi:foreign-symbol-pointer` without a `:library` argument always returns NIL.

CFFI passes `:default` as the library marker, but `clasp-ffi:%dlsym` only recognizes `:rtld-default` / `:rtld-next` and treats anything else as a library handle object, so the lookup silently fails. This one-liner translates `:default` to `:rtld-default` in the Clasp backend, matching what the other backends do for the default/global namespace.

Practical impact: cffi-libffi's `type-descriptor-ptr` resolves `ffi_type_sint32` etc. through the default library, so without this fix any struct-by-value call on Clasp fails immediately with `MAKE-LIBFFI-TYPE-DESCRIPTOR failed`.

Verified on Clasp (macOS arm64): with this change plus a Clasp runtime fix (clasp-developers/clasp#1792), the full cffi-libffi struct-by-value path works (scalar, struct-return, and nested-struct by-value calls, 300k-call stress run).