### PR TITLE
doc: Add example showing defcenum' base-type arg

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -2891,6 +2891,11 @@ CFFI> (foreign-enum-value 'boolean :no)
 CFFI> (foreign-enum-keyword 'numbers 2)
 @result{} :TWO
 @end lisp
+@lisp
+(defcenum (masks :uint32)
+  (:mask1 1)
+  (:mask2 2))
+@end lisp
 
 @subheading See Also
 @seealso{foreign-enum-value} @*


### PR DESCRIPTION
Add example showing the use of the `base-type` arg to `defcenum`.

See #433.