### PR TITLE
Update defcenum documentation

### DIFF
--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -2850,16 +2850,21 @@ An index value for a keyword.
 
 @subheading Description
 The @code{defcenum} macro is used to define foreign types that map
-keyword symbols to integer values, similar to the C @code{enum} type.
+symbols to integer values, similar to the C @code{enum}
+type.
 
 If @var{value} is omitted its value will either be 0, if it's the
 first entry, or it it will continue the progression from the last
 specified value.
 
-Keywords will be automatically converted to values and vice-versa when
-being passed as arguments to or returned from foreign functions,
-respectively. The same applies to any other situations where an object
-of an @code{enum} type is expected.
+When keywords are used for the enum value identifiers, they will be
+automatically converted to values and vice-versa when being passed as
+arguments to or returned from foreign functions, respectively. The
+same applies to any other situations where an object of an @code{enum}
+type is expected.
+
+When normal symbols are used as enum value identifiers, constants with
+the enum's value are also defined for those symbols.
 
 If a value should be translated to lisp that is not declared in the
 enum, an error will be signalled. You can elide this error and instead
@@ -2890,6 +2895,15 @@ CFFI> (foreign-enum-value 'boolean :no)
 
 CFFI> (foreign-enum-keyword 'numbers 2)
 @result{} :TWO
+@end lisp
+@lisp
+(defcenum enum-with-constants
+  (+one+ 1)
+  +two+
+  +three+)
+
+CFFI> +one+
+@result{} 1
 @end lisp
 @lisp
 (defcenum (masks :uint32)

--- a/doc/cffi-manual.texinfo
+++ b/doc/cffi-manual.texinfo
@@ -2874,8 +2874,14 @@ enumerations of which we only care about a subset of values, or for
 enumerations that should allow for client or vendor extensions that we
 cannot know about.
 
-Types defined with @code{defcenum} canonicalize to @var{base-type}
-which is @code{:int} by default.
+Types defined with @code{defcenum} canonicalize to @var{base-type}. If
+not specified, CFFI picks the smallest integer type that fits the
+values specified as defined by the C standard.@footnote{This is
+defined in
+@url{https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3299.pdf#subsubsection.6.7.3.3,
+Section 6.7.3.3}}@sup{,}@footnote{Note that on MS Windows,
+@url{https://learn.microsoft.com/en-us/cpp/build/reference/zc-enumtypes?view=msvc-180,
+the underlying enum type is not always standard compliant.}}
 
 @subheading Examples
 @lisp


### PR DESCRIPTION
+ Mention that `defcenum` produces constant definitions when non-keyword symbols are used for the enum value identifiers.
+ Update section on the underlying base type; CFFI follows the C standard, which doesn't guarantee that the underlying type is an `int`.
  + Also note that Windows doesn't always follow the standard.