### PR TITLE
clasp: define %foreign-funcall-varargs so variadic calls reach a variadic function type

### DIFF
--- a/src/cffi-clasp.lisp
+++ b/src/cffi-clasp.lisp
@@ -140,6 +140,30 @@ WITH-POINTER-TO-VECTOR-DATA."
   (declare (ignore convention))
   `(clasp-ffi:%foreign-funcall-pointer ,ptr ,@args))
 
+;;; Without these, CFFI falls back to appending FIXED-ARGS and VARARGS and calling
+;;; %FOREIGN-FUNCALL, which loses the distinction. Clasp then lowers the call
+;;; through a non-variadic function type. That is harmless on x86-64 SysV, where
+;;; variadic arguments use the same registers as fixed ones, and wrong on Darwin
+;;; arm64, where they are passed on the stack: the callee reads an unwritten slot,
+;;; so every variadic argument arrives as zero. shm_open's mode is the usual
+;;; casualty -- the object is created with st_mode 0 and cannot be reopened.
+;;; FIXED-ARGS is a flat type/value list, so the callee's fixed parameter count is
+;;; half its length; VARARGS carries the remaining pairs and the return type.
+
+(defmacro %foreign-funcall-varargs (name fixed-args varargs
+                                    &rest args &key convention library)
+  "Call a variadic foreign function."
+  (declare (ignore convention library))
+  `(clasp-ffi:%foreign-funcall-varargs ,name ,(floor (length fixed-args) 2)
+                                       ,@(append fixed-args varargs)))
+
+(defmacro %foreign-funcall-pointer-varargs (pointer fixed-args varargs
+                                            &rest args &key convention)
+  "Funcall a pointer to a variadic foreign function."
+  (declare (ignore convention))
+  `(clasp-ffi:%foreign-funcall-pointer-varargs ,pointer ,(floor (length fixed-args) 2)
+                                               ,@(append fixed-args varargs)))
+
 ;;;# Foreign Libraries
 
 (defun %load-foreign-library (name path)


### PR DESCRIPTION
CFFI carries the fixed/variadic split all the way down to the backend, and falls back to appending the two lists — discarding the distinction — when the backend does not define `%FOREIGN-FUNCALL-VARARGS` (`src/functions.lisp:153-165`). The Clasp backend does not define it, so every variadic call on Clasp goes through that fallback into `CLASP-FFI:%FOREIGN-FUNCALL`, which builds a **non-variadic** function type.

That is undefined behaviour in C, and the platforms differ:

* **x86-64 SysV** passes variadic arguments in the same registers as fixed ones, so the mistake is invisible.
* **Darwin arm64** passes them on the stack. The callee reads an unwritten slot and every variadic argument arrives as **zero**.

The symptom is a mode or flag that silently does nothing. On Clasp/macOS arm64, `shm_open(name, flags, 0600)` creates its object with `st_mode 0`, which cannot then be reopened; SBCL on the same machine gives `0600`.

This is the same platform issue `cffi-sbcl.lisp` already handles in its own backend, by inserting `&optional` into the alien signature under `#+(and darwin arm64)` with the comment *"All SBCL platforms would understand this but this is the only one where it's required."*

### The change

`cffi-clasp.lisp` defines `%FOREIGN-FUNCALL-VARARGS` and `%FOREIGN-FUNCALL-POINTER-VARARGS`, so CFFI stops using its fallback. `FIXED-ARGS` is a flat type/value list, so the callee's fixed parameter count is half its length; `VARARGS` carries the remaining pairs and the return type.

Verified end to end on Clasp/macOS arm64, in one process:

```
cffi plain (non-variadic)    -> FD_CLOEXEC = 0
cffi FOREIGN-FUNCALL-VARARGS -> FD_CLOEXEC = 1
```

`cffi-sys` already exports both symbols (`src/package.lisp:82-83`); the hook was there waiting for a backend to implement it.

### Ordering — please note

**This depends on Clasp support that does not exist in a released Clasp.** It calls `CLASP-FFI:%FOREIGN-FUNCALL-VARARGS`, added in clasp-developers/clasp#1847. Until that lands and Clasp's `repos.sexp` pin is advanced, this file will not compile on Clasp.

I am happy for this to sit until #1847 is merged, or to add a feature test so it degrades to the current fallback on older Clasp — whichever you prefer. I did not add one by default because a silent fallback would restore exactly the bug this fixes, and I would rather it fail loudly than pass a mode of zero.
